### PR TITLE
Feat/38 response builder v1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ LOGDIR		=	logs
 # =============================== COMPILATION ================================ #
 CXX			=	c++
 CXXFLAGS	=	-std=c++98 -Wall -Wextra -Werror -MMD -MP
-CXXFLAGS	+=	-I$(HDIR) -I$(HDIR)/config
+CXXFLAGS	+=	-I$(HDIR) -I$(HDIR)/config -I$(HDIR)/response
 # ================================== FILES =================================== #
 SRCS		:=	$(shell find $(SDIR) -name "*.cpp")
 OBJS		:=	$(patsubst $(SDIR)/%.cpp,$(ODIR)/%.o,$(SRCS))

--- a/config/example.conf
+++ b/config/example.conf
@@ -1,15 +1,25 @@
 server {
-	listen ; # Hello
-	# World
-	server_name example.com 127.0.0.1;
-	location / {
-		root html;
-		index index.html;
-	}
-	location /images/ {
-		root /etc/webserv/html;
-	}
-	location /blog/ {
-		root /tmp/webserv/html;
-	}
+    listen       9191;
+    server_name  localhost;
+
+    location /errorpage.html {
+        root /;
+    }
+
+    location /index.html {
+        root /;
+    }
+
+    location / {
+        root   /;
+        index  index.html;
+    }
+
+    location /logo.png {
+        root .;
+    }
+
+    location /favicon.ico {
+        root .;
+    }
 }

--- a/config/mime.types
+++ b/config/mime.types
@@ -1,3 +1,6 @@
+# ==============================
+#  Text and structured formats
+# ==============================
 text/html            html htm
 text/css             css
 text/csv             csv
@@ -5,9 +8,15 @@ text/plain           txt
 application/xml      xml
 application/json     json
 
+# ==============================
+#  JavaScript
+# ==============================
 application/javascript  mjs
 application/javascript  js
 
+# ==============================
+#  Images
+# ==============================
 image/png            png
 image/jpeg           jpg jpeg
 image/gif            gif
@@ -17,24 +26,36 @@ image/x-icon         ico
 image/bmp            bmp
 image/tiff           tif tiff
 
+# ==============================
+#  Audio formats
+# ==============================
 audio/mpeg           mp3
 audio/wav            wav
 audio/ogg            ogg
 audio/mp4            m4a
 audio/flac           flac
 
+# ==============================
+#  Video formats
+# ==============================
 video/mp4            mp4 m4v
 video/webm           webm
 video/ogg            ogv
 video/x-msvideo      avi
 video/quicktime      mov
 
+# ==============================
+#  Fonts
+# ==============================
 font/woff            woff
 font/woff2           woff2
 font/ttf             ttf
 font/otf             otf
 application/vnd.ms-fontobject eot
 
+# ==============================
+#  Archives and documents
+# ==============================
 application/pdf      pdf
 application/zip      zip
 application/x-tar    tar

--- a/config/mime.types
+++ b/config/mime.types
@@ -1,0 +1,53 @@
+text/html            html htm
+text/css             css
+text/csv             csv
+text/plain           txt
+application/xml      xml
+application/json     json
+
+application/javascript  mjs
+application/javascript  js
+
+image/png            png
+image/jpeg           jpg
+image/jpeg           jpeg
+image/gif            gif
+image/svg+xml        svg
+image/webp           webp
+image/x-icon         ico
+image/bmp            bmp
+image/tiff           tif
+image/tiff           tiff
+
+audio/mpeg           mp3
+audio/wav            wav
+audio/ogg            ogg
+audio/mp4            m4a
+audio/flac           flac
+
+video/mp4            mp4
+video/mp4            m4v
+video/webm           webm
+video/ogg            ogv
+video/x-msvideo      avi
+video/quicktime      mov
+
+font/woff            woff
+font/woff2           woff2
+font/ttf             ttf
+font/otf             otf
+application/vnd.ms-fontobject eot
+
+application/pdf      pdf
+application/zip      zip
+application/x-tar    tar
+application/gzip     gz
+application/vnd.rar  rar
+application/x-7z-compressed 7z
+
+application/msword   doc
+application/vnd.openxmlformats-officedocument.wordprocessingml.document docx
+application/vnd.ms-excel xls
+application/vnd.openxmlformats-officedocument.spreadsheetml.sheet xlsx
+application/vnd.ms-powerpoint ppt
+application/vnd.openxmlformats-officedocument.presentationml.presentation pptx

--- a/config/mime.types
+++ b/config/mime.types
@@ -9,15 +9,13 @@ application/javascript  mjs
 application/javascript  js
 
 image/png            png
-image/jpeg           jpg
-image/jpeg           jpeg
+image/jpeg           jpg jpeg
 image/gif            gif
 image/svg+xml        svg
 image/webp           webp
 image/x-icon         ico
 image/bmp            bmp
-image/tiff           tif
-image/tiff           tiff
+image/tiff           tif tiff
 
 audio/mpeg           mp3
 audio/wav            wav
@@ -25,8 +23,7 @@ audio/ogg            ogg
 audio/mp4            m4a
 audio/flac           flac
 
-video/mp4            mp4
-video/mp4            m4v
+video/mp4            mp4 m4v
 video/webm           webm
 video/ogg            ogv
 video/x-msvideo      avi

--- a/inc/response/HttpStatus.hpp
+++ b/inc/response/HttpStatus.hpp
@@ -4,105 +4,114 @@
  * @namespace HttpStatus
  * @brief Utilities for working with HTTP status codes and messages.
  */
-namespace HttpStatus {
+namespace http {
 
-	/**
-	 * @enum Status
-	 * @brief Enumeration of common HTTP status codes.
-	 */
-	enum Status {
-		OK                   = 200, /** 200 OK — request succeeded. */
-		CREATED              = 201, /** 201 Created — resource created. */
-		ACCEPTED             = 202, /** 202 Accepted — processing pending. */
-		NO_CONTENT           = 204, /** 204 No Content — successful, no body. */
+/**
+ * @enum Status
+ * @brief Enumeration of common HTTP status codes.
+ */
+enum Status {
+    OK = 200,         /** 200 OK — request succeeded. */
+    CREATED = 201,    /** 201 Created — resource created. */
+    ACCEPTED = 202,   /** 202 Accepted — processing pending. */
+    NO_CONTENT = 204, /** 204 No Content — successful, no body. */
 
-		BAD_REQUEST          = 400, /** 400 Bad Request — malformed syntax. */
-		UNAUTHORIZED         = 401, /** 401 Unauthorized — authentication required/failed. */
-		FORBIDDEN            = 403, /** 403 Forbidden — not allowed despite authentication. */
-		NOT_FOUND            = 404, /** 404 Not Found — resource not found. */
-		METHOD_NOT_ALLOWED   = 405, /** 405 Method Not Allowed — method not permitted. */
+    BAD_REQUEST = 400,        /** 400 Bad Request — malformed syntax. */
+    UNAUTHORIZED = 401,       /** 401 Unauthorized — authentication required/failed. */
+    FORBIDDEN = 403,          /** 403 Forbidden — not allowed despite authentication. */
+    NOT_FOUND = 404,          /** 404 Not Found — resource not found. */
+    METHOD_NOT_ALLOWED = 405, /** 405 Method Not Allowed — method not permitted. */
 
-		INTERNAL_SERVER_ERROR = 500 /** 500 Internal Server Error — server-side failure. */
-	};
+    INTERNAL_SERVER_ERROR = 500 /** 500 Internal Server Error — server-side failure. */
+};
 
-	/**
-	 * @brief Returns the canonical reason phrase for a given HTTP status code.
-	 *
-	 * @param status The HTTP status code.
-	 * @return A pointer to a null-terminated string with the reason phrase,
-	 *         e.g., "OK", "Not Found". Returns "Unknown" if the status
-	 *         is not recognized.
-	 */
-	inline const char* statusMessage(Status status) {
-		switch (status) {
-			case OK: return "OK";
-			case CREATED: return "Created";
-			case ACCEPTED: return "Accepted";
-			case NO_CONTENT: return "No Content";
-			case BAD_REQUEST: return "Bad Request";
-			case UNAUTHORIZED: return "Unauthorized";
-			case FORBIDDEN: return "Forbidden";
-			case NOT_FOUND: return "Not Found";
-			case METHOD_NOT_ALLOWED: return "Method Not Allowed";
-			case INTERNAL_SERVER_ERROR: return "Internal Server Error";
-			default: return "Unknown";
-		}
-	}
+/**
+ * @brief Returns the canonical reason phrase for a given HTTP status code.
+ *
+ * @param status The HTTP status code.
+ * @return A pointer to a null-terminated string with the reason phrase,
+ *         e.g., "OK", "Not Found". Returns "Unknown" if the status
+ *         is not recognized.
+ */
+inline const char *statusMessage(Status status) {
+    switch (status) {
+    case OK:
+        return "OK";
+    case CREATED:
+        return "Created";
+    case ACCEPTED:
+        return "Accepted";
+    case NO_CONTENT:
+        return "No Content";
+    case BAD_REQUEST:
+        return "Bad Request";
+    case UNAUTHORIZED:
+        return "Unauthorized";
+    case FORBIDDEN:
+        return "Forbidden";
+    case NOT_FOUND:
+        return "Not Found";
+    case METHOD_NOT_ALLOWED:
+        return "Method Not Allowed";
+    case INTERNAL_SERVER_ERROR:
+        return "Internal Server Error";
+    default:
+        return "Unknown";
+    }
+}
 
-	/**
-	 * @class StatusCode
-	 * @brief Lightweight wrapper around an HTTP @ref Status value with helpers.
-	 *
-	 * Provides access to the numeric status code and its reason phrase.
-	 */
-	class StatusCode
-	{
+/**
+ * @class StatusCode
+ * @brief Lightweight wrapper around an HTTP @ref Status value with helpers.
+ *
+ * Provides access to the numeric status code and its reason phrase.
+ */
+class StatusCode {
 
-	public:
-		/**
-		 * @brief Default constructor.
-		 * Initializes the status code to 200 OK.
-		 */
-		StatusCode();
-		/**
-		 * @brief Constructs a StatusCode from a @ref Status value.
-		 * @param code The HTTP status to store.
-		 */
-		explicit StatusCode(Status code);
+public:
+    /**
+     * @brief Default constructor.
+     * Initializes the status code to 200 OK.
+     */
+    StatusCode();
+    /**
+     * @brief Constructs a StatusCode from a @ref Status value.
+     * @param code The HTTP status to store.
+     */
+    explicit StatusCode(Status code);
 
-		/**
-		 * @brief Copy constructor.
-		 * @param other The instance to copy from.
-		 */
-		StatusCode(const StatusCode& other);
+    /**
+     * @brief Copy constructor.
+     * @param other The instance to copy from.
+     */
+    StatusCode(const StatusCode &other);
 
-		/**
-		 * @brief Copy assignment operator.
-		 * @param other The instance to copy from.
-		 * @return Reference to this instance.
-		 */
-		StatusCode& operator=(const StatusCode& other);
+    /**
+     * @brief Copy assignment operator.
+     * @param other The instance to copy from.
+     * @return Reference to this instance.
+     */
+    StatusCode &operator=(const StatusCode &other);
 
-		/**
-		 * @brief Returns the stored HTTP status code.
-		 * @return The @ref Status value.
-		 */
-		Status getCode() const;
+    /**
+     * @brief Returns the stored HTTP status code.
+     * @return The @ref Status value.
+     */
+    Status getCode() const;
 
-		/**
-		 * @brief Returns the canonical reason phrase for the stored code.
-		 * @return A pointer to a null-terminated string with the reason phrase.
-		 */
-		const char* getMessage() const;
+    /**
+     * @brief Returns the canonical reason phrase for the stored code.
+     * @return A pointer to a null-terminated string with the reason phrase.
+     */
+    const char *getMessage() const;
 
-		/**
-		 * @brief Destructor.
-		 */
-		~StatusCode();
+    /**
+     * @brief Destructor.
+     */
+    ~StatusCode();
 
-	private:
-		Status code_; /**< Stored HTTP status code. */
-	};
+private:
+    Status code_; /**< Stored HTTP status code. */
+};
 
-} // namespace HttpStatus
-
+} // namespace http

--- a/inc/response/HttpStatus.hpp
+++ b/inc/response/HttpStatus.hpp
@@ -1,0 +1,108 @@
+#pragma once
+
+/**
+ * @namespace HttpStatus
+ * @brief Utilities for working with HTTP status codes and messages.
+ */
+namespace HttpStatus {
+
+	/**
+	 * @enum Status
+	 * @brief Enumeration of common HTTP status codes.
+	 */
+	enum Status {
+		OK                   = 200, /** 200 OK — request succeeded. */
+		CREATED              = 201, /** 201 Created — resource created. */
+		ACCEPTED             = 202, /** 202 Accepted — processing pending. */
+		NO_CONTENT           = 204, /** 204 No Content — successful, no body. */
+
+		BAD_REQUEST          = 400, /** 400 Bad Request — malformed syntax. */
+		UNAUTHORIZED         = 401, /** 401 Unauthorized — authentication required/failed. */
+		FORBIDDEN            = 403, /** 403 Forbidden — not allowed despite authentication. */
+		NOT_FOUND            = 404, /** 404 Not Found — resource not found. */
+		METHOD_NOT_ALLOWED   = 405, /** 405 Method Not Allowed — method not permitted. */
+
+		INTERNAL_SERVER_ERROR = 500 /** 500 Internal Server Error — server-side failure. */
+	};
+
+	/**
+	 * @brief Returns the canonical reason phrase for a given HTTP status code.
+	 *
+	 * @param status The HTTP status code.
+	 * @return A pointer to a null-terminated string with the reason phrase,
+	 *         e.g., "OK", "Not Found". Returns "Unknown" if the status
+	 *         is not recognized.
+	 */
+	inline const char* statusMessage(Status status) {
+		switch (status) {
+			case OK: return "OK";
+			case CREATED: return "Created";
+			case ACCEPTED: return "Accepted";
+			case NO_CONTENT: return "No Content";
+			case BAD_REQUEST: return "Bad Request";
+			case UNAUTHORIZED: return "Unauthorized";
+			case FORBIDDEN: return "Forbidden";
+			case NOT_FOUND: return "Not Found";
+			case METHOD_NOT_ALLOWED: return "Method Not Allowed";
+			case INTERNAL_SERVER_ERROR: return "Internal Server Error";
+			default: return "Unknown";
+		}
+	}
+
+	/**
+	 * @class StatusCode
+	 * @brief Lightweight wrapper around an HTTP @ref Status value with helpers.
+	 *
+	 * Provides access to the numeric status code and its reason phrase.
+	 */
+	class StatusCode
+	{
+
+	public:
+		/**
+		 * @brief Default constructor.
+		 * Initializes the status code to 200 OK.
+		 */
+		StatusCode();
+		/**
+		 * @brief Constructs a StatusCode from a @ref Status value.
+		 * @param code The HTTP status to store.
+		 */
+		explicit StatusCode(Status code);
+
+		/**
+		 * @brief Copy constructor.
+		 * @param other The instance to copy from.
+		 */
+		StatusCode(const StatusCode& other);
+
+		/**
+		 * @brief Copy assignment operator.
+		 * @param other The instance to copy from.
+		 * @return Reference to this instance.
+		 */
+		StatusCode& operator=(const StatusCode& other);
+
+		/**
+		 * @brief Returns the stored HTTP status code.
+		 * @return The @ref Status value.
+		 */
+		Status getCode() const;
+
+		/**
+		 * @brief Returns the canonical reason phrase for the stored code.
+		 * @return A pointer to a null-terminated string with the reason phrase.
+		 */
+		const char* getMessage() const;
+
+		/**
+		 * @brief Destructor.
+		 */
+		~StatusCode();
+
+	private:
+		Status code_; /**< Stored HTTP status code. */
+	};
+
+} // namespace HttpStatus
+

--- a/inc/response/MimeTypes.hpp
+++ b/inc/response/MimeTypes.hpp
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <string>
+#include <map>
+#include <iostream>
+#include <fcntl.h>           /* Definition of AT_* constants */
+#include <sys/stat.h>
+
+#define MIME_TYPES_PATH "config/mime.types"
+
+class MimeTypes
+{
+public:
+
+	/**
+	 * @brief Constructs the MimeTypes object and loads MIME types from the specified file.
+	 *
+	 * This constructor initializes the MIME types map by reading from the provided
+	 * file path. It sets the last reload time to the last modification time of the file.
+	 * If the file cannot be loaded, throws a runtime_error exception.
+	 *
+	 * @param path Optional parameter path to the MIME types configuration file. Defaults to "MIME_TYPES_PATH".
+	 */
+	MimeTypes(const std::string& path = MIME_TYPES_PATH);
+
+	/**
+	 * @brief Copy constructor.
+	 *
+	 * This constructor creates a new MimeTypes object as a copy of an existing one.
+	 *
+	 * @param other The MimeTypes object to copy.
+	 */
+	MimeTypes(const MimeTypes& other);
+
+	/**
+	 * @brief Assignment operator.
+	 *
+	 * This operator assigns the contents of one MimeTypes object to another.
+	 *
+	 * @param other The MimeTypes object to assign from.
+	 * @return A reference to this MimeTypes object.
+	 */
+	MimeTypes& operator=(const MimeTypes& other);
+	
+	/**
+	 * @brief Retrieves the MIME type associated with a given file extension.
+	 *
+	 * This method looks up the MIME type corresponding to the provided file
+	 * extension in the loaded MIME types map..
+	 *
+	 * @param extension The file extension (without the leading dot) for which
+	 *                  to retrieve the MIME type.
+	 * @return The corresponding MIME type as a string, or "text/plain"
+	 *         if the extension is not recognized.
+	 */
+	const std::string getMimeType(const std::string &extension);
+
+	~MimeTypes();
+
+private:
+	/*map<extensoin, type> mimeTypes_*/
+	std::map<std::string, std::string> mimeTypes_; // Map of file extensions to MIME types
+	std::string filePath_; // Path to the MIME types configuration file
+	struct timespec rtime_; // last reload time
+
+	/**
+	 * @brief checks if the MIME types file has been modified since the last load.
+	 */
+	bool wasChanged();
+
+	/**
+	 * @brief Reloads the MIME types from the configuration file.
+	 *
+	 * This method reads the MIME types file specified by `filePath_` and
+	 * populates the `mimeTypes_` map with the latest MIME type definitions.
+	 * It updates the `rtime_` to reflect the time of the last successful
+	 * reload.
+	 */
+	void reload();
+
+	size_t findFirstSpace(const std::string str);
+	size_t findFirstNonSpace(const std::string str, size_t startPos);
+};
+

--- a/inc/response/Response.hpp
+++ b/inc/response/Response.hpp
@@ -1,0 +1,100 @@
+#pragma once
+
+#include <string>
+#include <sstream>
+#include "HttpStatus.hpp"
+#include "ResponseContent.hpp"
+
+/**
+ * @class Response
+ * @brief Represents a complete HTTP response message.
+ *
+ * The Response class encapsulates the HTTP version string,
+ * a status code (with its numeric code and reason phrase),
+ * and the response content (body + MIME type).
+ */
+class Response {
+public:
+	/**
+	 * @brief Default constructor.
+	 *
+	 * Initializes an empty response with default members.
+	 */
+	Response();
+
+	/**
+	 * @brief Constructs a response with specified version, status, and content.
+	 *
+	 * @param httpVersion The HTTP version string (e.g., "HTTP/1.1").
+	 * @param statusCode  The HTTP status code and reason phrase wrapper.
+	 * @param content     The response body and MIME type.
+	 * @param connectionType The connection type (e.g., "close").
+	 */
+	Response(const std::string& httpVersion,
+			const std::string& connectionType,
+			const HttpStatus::StatusCode& statusCode,
+			const ResponseContent& content);
+
+	/**
+	 * @brief Copy constructor.
+	 *
+	 * Creates a new Response object as a copy of another.
+	 *
+	 * @param other The response to copy from.
+	 */
+	Response(const Response& other);
+
+	/**
+	 * @brief Copy assignment operator.
+	 *
+	 * Replaces the contents of this Response with another.
+	 *
+	 * @param other The response to copy from.
+	 * @return Reference to this instance.
+	 */
+	Response& operator=(const Response& other);
+
+	/**
+	 * @brief Gets the HTTP version string of the response.
+	 *
+	 * @return Constant reference to the version string.
+	 */
+	const std::string& getHttpVersion() const;
+
+	/**
+	 * @brief Gets the response content (body + MIME type).
+	 *
+	 * @return Constant reference to the ResponseContent object.
+	 */
+	const ResponseContent& getContent() const;
+
+	/**
+	 * @brief Gets the HTTP status code and reason phrase.
+	 *
+	 * @return Constant reference to the HttpStatus::StatusCode object.
+	 */
+	const HttpStatus::StatusCode& getStatusCode() const;
+
+	/**
+	 * @brief Converts the response to a string representation.
+	 *
+	 * Builds the full HTTP response string including headers and body.
+	 *
+	 * @return The complete HTTP response as a string.
+	 */
+	std::string toString() const;
+
+	/**
+	 * @brief Destructor.
+	 */
+	~Response();
+
+private:
+	std::string httpVersion_;        /**< HTTP version string, e.g. "HTTP/1.1". */
+	std::string connectionType_;      /**< Connection type, e.g. "close". */
+	HttpStatus::StatusCode statusCode_; /**< HTTP status code and reason phrase. */
+	ResponseContent content_;        /**< Response body and its MIME type. */
+	std::ostringstream respStream_; /**< Stream for building the response string. */
+
+	void buildResponseStream();
+};

--- a/inc/response/Response.hpp
+++ b/inc/response/Response.hpp
@@ -15,86 +15,84 @@
  */
 class Response {
 public:
-	/**
-	 * @brief Default constructor.
-	 *
-	 * Initializes an empty response with default members.
-	 */
-	Response();
+    /**
+     * @brief Default constructor.
+     *
+     * Initializes an empty response with default members.
+     */
+    Response();
 
-	/**
-	 * @brief Constructs a response with specified version, status, and content.
-	 *
-	 * @param httpVersion The HTTP version string (e.g., "HTTP/1.1").
-	 * @param statusCode  The HTTP status code and reason phrase wrapper.
-	 * @param content     The response body and MIME type.
-	 * @param connectionType The connection type (e.g., "close").
-	 */
-	Response(const std::string& httpVersion,
-			const std::string& connectionType,
-			const HttpStatus::StatusCode& statusCode,
-			const ResponseContent& content);
+    /**
+     * @brief Constructs a response with specified version, status, and content.
+     *
+     * @param httpVersion The HTTP version string (e.g., "HTTP/1.1").
+     * @param statusCode  The HTTP status code and reason phrase wrapper.
+     * @param content     The response body and MIME type.
+     * @param connectionType The connection type (e.g., "close").
+     */
+    Response(const std::string &httpVersion, const std::string &connectionType,
+             const http::StatusCode &statusCode, const ResponseContent &content);
 
-	/**
-	 * @brief Copy constructor.
-	 *
-	 * Creates a new Response object as a copy of another.
-	 *
-	 * @param other The response to copy from.
-	 */
-	Response(const Response& other);
+    /**
+     * @brief Copy constructor.
+     *
+     * Creates a new Response object as a copy of another.
+     *
+     * @param other The response to copy from.
+     */
+    Response(const Response &other);
 
-	/**
-	 * @brief Copy assignment operator.
-	 *
-	 * Replaces the contents of this Response with another.
-	 *
-	 * @param other The response to copy from.
-	 * @return Reference to this instance.
-	 */
-	Response& operator=(const Response& other);
+    /**
+     * @brief Copy assignment operator.
+     *
+     * Replaces the contents of this Response with another.
+     *
+     * @param other The response to copy from.
+     * @return Reference to this instance.
+     */
+    Response &operator=(const Response &other);
 
-	/**
-	 * @brief Gets the HTTP version string of the response.
-	 *
-	 * @return Constant reference to the version string.
-	 */
-	const std::string& getHttpVersion() const;
+    /**
+     * @brief Gets the HTTP version string of the response.
+     *
+     * @return Constant reference to the version string.
+     */
+    const std::string &getHttpVersion() const;
 
-	/**
-	 * @brief Gets the response content (body + MIME type).
-	 *
-	 * @return Constant reference to the ResponseContent object.
-	 */
-	const ResponseContent& getContent() const;
+    /**
+     * @brief Gets the response content (body + MIME type).
+     *
+     * @return Constant reference to the ResponseContent object.
+     */
+    const ResponseContent &getContent() const;
 
-	/**
-	 * @brief Gets the HTTP status code and reason phrase.
-	 *
-	 * @return Constant reference to the HttpStatus::StatusCode object.
-	 */
-	const HttpStatus::StatusCode& getStatusCode() const;
+    /**
+     * @brief Gets the HTTP status code and reason phrase.
+     *
+     * @return Constant reference to the http::StatusCode object.
+     */
+    const http::StatusCode &getStatusCode() const;
 
-	/**
-	 * @brief Converts the response to a string representation.
-	 *
-	 * Builds the full HTTP response string including headers and body.
-	 *
-	 * @return The complete HTTP response as a string.
-	 */
-	std::string toString() const;
+    /**
+     * @brief Converts the response to a string representation.
+     *
+     * Builds the full HTTP response string including headers and body.
+     *
+     * @return The complete HTTP response as a string.
+     */
+    std::string toString() const;
 
-	/**
-	 * @brief Destructor.
-	 */
-	~Response();
+    /**
+     * @brief Destructor.
+     */
+    ~Response();
 
 private:
-	std::string httpVersion_;        /**< HTTP version string, e.g. "HTTP/1.1". */
-	std::string connectionType_;      /**< Connection type, e.g. "close". */
-	HttpStatus::StatusCode statusCode_; /**< HTTP status code and reason phrase. */
-	ResponseContent content_;        /**< Response body and its MIME type. */
-	std::ostringstream respStream_; /**< Stream for building the response string. */
+    std::string httpVersion_;       /**< HTTP version string, e.g. "HTTP/1.1". */
+    std::string connectionType_;    /**< Connection type, e.g. "close". */
+    http::StatusCode statusCode_;   /**< HTTP status code and reason phrase. */
+    ResponseContent content_;       /**< Response body and its MIME type. */
+    std::ostringstream respStream_; /**< Stream for building the response string. */
 
-	void buildResponseStream();
+    void buildResponseStream();
 };

--- a/inc/response/Response.hpp
+++ b/inc/response/Response.hpp
@@ -5,6 +5,7 @@
 #include "HttpStatus.hpp"
 #include "ResponseContent.hpp"
 
+namespace http {
 /**
  * @class Response
  * @brief Represents a complete HTTP response message.
@@ -96,3 +97,5 @@ private:
 
     void buildResponseStream();
 };
+
+} // namespace http

--- a/inc/response/ResponseBuilder.hpp
+++ b/inc/response/ResponseBuilder.hpp
@@ -97,10 +97,10 @@ public:
      *
      * @return Constant reference to the Response instance.
      */
-    const Response &getResponse() const;
+    const http::Response &getResponse() const;
 
 private:
-    Response response_;                      /**< The current response object. */
+    http::Response response_;                /**< The current response object. */
     const config::ServerBlock *serverBlock_; /**< Pointer to the server block configuration. */
     bool serverBlockSet_;                    /**< Flag indicating if the server block is set. */
 
@@ -111,29 +111,4 @@ private:
 
     bool errorHandling(const std::string &httpVersion, const std::string &connectionType,
                        const std::string &filePath);
-    // /**
-    //  * @brief Helper to build a file-based response.
-    //  *
-    //  * @param httpVersion    HTTP version string.
-    //  * @param connectionType Connection type string.
-    //  * @param filePath       Path to the file.
-    //  * @param headOnly       If true, build headers only (HEAD request).
-    //  * @param mimeHint       Optional MIME type hint.
-    //  * @return True if built successfully, false otherwise.
-    //  */
-    // bool buildFileResponse_(const std::string &httpVersion, const std::string &connectionType,
-    //                         const std::string &filePath, bool headOnly,
-    //                         const std::string &mimeHint);
-
-    // /**
-    //  * @brief Helper to build an error response.
-    //  *
-    //  * @param httpVersion    HTTP version string.
-    //  * @param connectionType Connection type string.
-    //  * @param status         HTTP status code object.
-    //  * @param customBody     Optional custom body message.
-    //  * @return True if built successfully, false otherwise.
-    //  */
-    // bool buildErrorResponse_(const std::string &httpVersion, const std::string &connectionType,
-    //                          const http::StatusCode &status, const std::string &customBody);
 };

--- a/inc/response/ResponseBuilder.hpp
+++ b/inc/response/ResponseBuilder.hpp
@@ -1,0 +1,139 @@
+#pragma once
+
+#include <string>
+#include "HttpStatus.hpp"
+#include "Response.hpp"
+#include "ServerConfig.hpp"
+
+/**
+ * @class ResponseBuilder
+ * @brief Utility class for constructing and sending HTTP response messages.
+ *
+ * The ResponseBuilder provides high-level methods to build responses for
+ * different scenarios (serving files, handling errors, redirects, etc.)
+ * and helper methods for serializing and sending the response over a socket.
+ */
+class ResponseBuilder {
+public:
+    /**
+     * @brief Constructor with port and server name.
+     *
+     * Initializes the ResponseBuilder with a specific port and server name.
+     * This constructor is useful for building responses based on server configuration.
+     *
+     * @param port The port number to use for the response.
+     * @param server_name The server name to use for the response.
+     * @param serverConfig The server configuration reference to use for matching server blocks.
+     *
+     * @note This constructor does not build a response; it only initializes the internal state.
+     *       Use the `build` method to create a response based on the server configuration.
+     */
+    ResponseBuilder(int port, const std::string &server_name,
+                    const config::ServerConfig &serverConfig);
+
+    /**
+     * @brief Builds a response based on request information and server configuration.
+     *
+     * @param httpVersion    HTTP version string (e.g., "HTTP/1.1").
+     * @param connectionType Connection type (e.g., "close" or "keep-alive").
+     * @param method         HTTP request method (e.g., "GET", "HEAD").
+     * @param dirPath       Path to the requested resource directory.
+     * @param filename       Filename for the requested resource.
+     * @return True if response was successfully built, false otherwise.
+     */
+    bool build(const std::string &httpVersion, const std::string &connectionType,
+               const std::string &method, const std::string &dirPath, const std::string &filename);
+
+    /**
+     * @brief Builds a GET response for serving a file.
+     *
+     * @param httpVersion    HTTP version string.
+     * @param connectionType Connection type string.
+     * @param dirPath        Path to the file directory to serve metadata for.
+     * @param filename       Filename for the requested resource.
+     * @return True if the response was successfully built, false otherwise.
+     */
+    bool buildGetFile(const std::string &httpVersion, const std::string &connectionType,
+                      const std::string &dirPath, const std::string &filename);
+
+    // /**
+    //  * @brief Builds a HEAD response (headers only, no body).
+    //  *
+    //  * @param httpVersion    HTTP version string.
+    //  * @param connectionType Connection type string.
+    //  * @param dirPath        Path to the file directory to serve metadata for.
+    //  * @param filename       Filename for the requested resource.
+    //  * @return True if the response was successfully built, false otherwise.
+    //  */
+    // bool buildHeadFile(const std::string &httpVersion, const std::string &connectionType,
+    //                    const std::string &dirPath, const std::string &filename);
+
+    /**
+     * @brief Builds an error response.
+     *
+     * @param httpVersion    HTTP version string.
+     * @param connectionType Connection type string.
+     * @param status         HTTP status code object.
+     * @param filePath       Path to a file for the error response body.
+     * @return True if the response was successfully built, false otherwise.
+     */
+    bool buildError(const std::string &httpVersion, const std::string &connectionType,
+                    const http::Status &status, const std::string &filePath);
+
+    // /**
+    //  * @brief Builds a redirect response.
+    //  *
+    //  * @param httpVersion    HTTP version string.
+    //  * @param connectionType Connection type string.
+    //  * @param location       Redirect target (Location header).
+    //  * @param status         Redirect status code (e.g., 301, 302).
+    //  * @return True if the response was successfully built, false otherwise.
+    //  */
+    // bool buildRedirect(const std::string &httpVersion, const std::string &connectionType,
+    //                    const std::string &location, const http::StatusCode &status);
+
+    /**
+     * @brief Gets the internal Response object.
+     *
+     * @return Constant reference to the Response instance.
+     */
+    const Response &getResponse() const;
+
+private:
+    Response response_;                      /**< The current response object. */
+    const config::ServerBlock *serverBlock_; /**< Pointer to the server block configuration. */
+    bool serverBlockSet_;                    /**< Flag indicating if the server block is set. */
+
+    /**
+     * @brief Default constructor.
+     */
+    ResponseBuilder();
+
+    bool errorHandling(const std::string &httpVersion, const std::string &connectionType,
+                       const std::string &filePath);
+    // /**
+    //  * @brief Helper to build a file-based response.
+    //  *
+    //  * @param httpVersion    HTTP version string.
+    //  * @param connectionType Connection type string.
+    //  * @param filePath       Path to the file.
+    //  * @param headOnly       If true, build headers only (HEAD request).
+    //  * @param mimeHint       Optional MIME type hint.
+    //  * @return True if built successfully, false otherwise.
+    //  */
+    // bool buildFileResponse_(const std::string &httpVersion, const std::string &connectionType,
+    //                         const std::string &filePath, bool headOnly,
+    //                         const std::string &mimeHint);
+
+    // /**
+    //  * @brief Helper to build an error response.
+    //  *
+    //  * @param httpVersion    HTTP version string.
+    //  * @param connectionType Connection type string.
+    //  * @param status         HTTP status code object.
+    //  * @param customBody     Optional custom body message.
+    //  * @return True if built successfully, false otherwise.
+    //  */
+    // bool buildErrorResponse_(const std::string &httpVersion, const std::string &connectionType,
+    //                          const http::StatusCode &status, const std::string &customBody);
+};

--- a/inc/response/ResponseContent.hpp
+++ b/inc/response/ResponseContent.hpp
@@ -5,6 +5,7 @@
 
 #define MIME_TYPES_PATH "config/mime.types"
 
+namespace http {
 /**
  * @class ResponseContent
  * @brief Encapsulates the body content and MIME type of an HTTP response.
@@ -109,3 +110,5 @@ private:
      */
     void setFileType(const std::string &path);
 };
+
+} // namespace http

--- a/inc/response/ResponseContent.hpp
+++ b/inc/response/ResponseContent.hpp
@@ -1,0 +1,112 @@
+#pragma once
+
+#include <cstddef>
+#include <string>
+
+#define MIME_TYPES_PATH "config/mime.types"
+
+/**
+ * @class ResponseContent
+ * @brief Encapsulates the body content and MIME type of an HTTP response.
+ *
+ * This class stores both the content (body) and the corresponding MIME type
+ * for HTTP responses. It provides constructors for initializing the response
+ * from a file path, from a raw body and MIME type, or by copying another
+ * instance. It also provides accessors for retrieving the stored data and
+ * utility methods for determining the MIME type from a file extension.
+ */
+class ResponseContent {
+public:
+    /**
+     * @brief Default constructor.
+     *
+     * Initializes an empty response body and sets the MIME type to "text/plain".
+     */
+    ResponseContent();
+
+    /**
+     * @brief Constructs the response from a file.
+     *
+     * Reads the file at the given path, stores its content in the body,
+     * and determines its MIME type by calling setFileType().
+     *
+     * @param path Path to the file to be read.
+     */
+    ResponseContent(const char* path);
+
+    /**
+     * @brief Constructs the response from raw body content and MIME type.
+     *
+     * @param body Body content to store.
+     * @param type MIME type to associate with the body.
+     */
+    ResponseContent(const std::string& body, const std::string& type);
+
+    /**
+     * @brief Copy constructor.
+     *
+     * Creates a new instance as a copy of another ResponseContent object.
+     *
+     * @param other Instance to copy from.
+     */
+    ResponseContent(const ResponseContent& other);
+
+    /**
+     * @brief Copy assignment operator.
+     *
+     * Replaces the contents of this instance with those from another instance.
+     *
+     * @param other Instance to copy from.
+     * @return Reference to this instance.
+     */
+    ResponseContent& operator=(const ResponseContent& other);
+
+    /**
+     * @brief Retrieves the stored response body.
+     *
+     * @return Constant reference to the body string.
+     */
+    const std::string& getBody() const;
+
+    /**
+     * @brief Retrieves the stored MIME type.
+     *
+     * @return Constant reference to the MIME type string.
+     */
+    const std::string& getType() const;
+
+    /**
+     * @brief Retrieves the length of the body content in bytes.
+     *
+     * @return Size of the body string.
+     */
+    size_t getContentLength() const;
+
+    /**
+     * @brief Destructor.
+     */
+    ~ResponseContent();
+
+private:
+    std::string body_; /**< The content of the response body. */
+    std::string type_; /**< The MIME type of the response content. */
+
+    /**
+     * @brief Determines the MIME type of a file based on its extension.
+     *
+     * Reads the list of MIME types from the file defined by @ref MIME_TYPES_PATH.
+     * The expected format for each line in the MIME types file is:
+     *   <mime-type> <ext1> <ext2> ... <extN>
+     * For example:
+     *   text/html html htm
+     *   image/png png
+     *
+     * The function matches the extension of the given path to find
+     * the corresponding type. If no match is found, sets the type to
+     * "text/plain".
+     *
+     * @param path Path to the file whose MIME type should be determined.
+     */
+    void setFileType(const std::string &path);
+};
+

--- a/inc/response/ResponseContent.hpp
+++ b/inc/response/ResponseContent.hpp
@@ -32,7 +32,7 @@ public:
      *
      * @param path Path to the file to be read.
      */
-    ResponseContent(const char* path);
+    ResponseContent(const char *path);
 
     /**
      * @brief Constructs the response from raw body content and MIME type.
@@ -40,7 +40,7 @@ public:
      * @param body Body content to store.
      * @param type MIME type to associate with the body.
      */
-    ResponseContent(const std::string& body, const std::string& type);
+    ResponseContent(const std::string &body, const std::string &type);
 
     /**
      * @brief Copy constructor.
@@ -49,7 +49,7 @@ public:
      *
      * @param other Instance to copy from.
      */
-    ResponseContent(const ResponseContent& other);
+    ResponseContent(const ResponseContent &other);
 
     /**
      * @brief Copy assignment operator.
@@ -59,21 +59,21 @@ public:
      * @param other Instance to copy from.
      * @return Reference to this instance.
      */
-    ResponseContent& operator=(const ResponseContent& other);
+    ResponseContent &operator=(const ResponseContent &other);
 
     /**
      * @brief Retrieves the stored response body.
      *
      * @return Constant reference to the body string.
      */
-    const std::string& getBody() const;
+    const std::string &getBody() const;
 
     /**
      * @brief Retrieves the stored MIME type.
      *
      * @return Constant reference to the MIME type string.
      */
-    const std::string& getType() const;
+    const std::string &getType() const;
 
     /**
      * @brief Retrieves the length of the body content in bytes.
@@ -109,4 +109,3 @@ private:
      */
     void setFileType(const std::string &path);
 };
-

--- a/inc/response/ResponseSend.hpp
+++ b/inc/response/ResponseSend.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <string>
+#include <sys/types.h>
+#include "Response.hpp"
+
+/**
+ * @class ResponseSend
+ * @brief Utility class for sending HTTP responses over a socket.
+ * This class provides methods to send complete responses or parts of them
+ * to a client socket.
+ */
+class ResponseSend {
+public:
+    /**
+     * @brief Sends the entire response to the specified client socket.
+     *
+     * @param clientFd File descriptor of the client socket.
+     * @return True if the response was sent successfully, false otherwise.
+     */
+    static bool sendAll(int clientFd, const Response &response);
+
+    /**
+     * @brief Sends the entire data buffer to the client socket.
+     *
+     * @param clientFd File descriptor of the client socket.
+     * @param data     Data buffer to send.
+     * @return True if the data was sent successfully, false otherwise.
+     */
+    static bool sendAll(int clientFd, const std::string &data);
+
+    /**
+     * @brief Sends part of the data buffer to the client socket.
+     *
+     * Useful for non-blocking sockets.
+     *
+     * @param clientFd File descriptor of the client socket.
+     * @param data     Data buffer to send.
+     * @return Number of bytes sent, or -1 on error.
+     */
+    static long sendSome(int clientFd, const std::string &data);
+};

--- a/inc/response/ResponseSend.hpp
+++ b/inc/response/ResponseSend.hpp
@@ -18,7 +18,7 @@ public:
      * @param clientFd File descriptor of the client socket.
      * @return True if the response was sent successfully, false otherwise.
      */
-    static bool sendAll(int clientFd, const Response &response);
+    static bool sendAll(int clientFd, const http::Response &response);
 
     /**
      * @brief Sends the entire data buffer to the client socket.

--- a/src/response/HttpStatus.cpp
+++ b/src/response/HttpStatus.cpp
@@ -1,28 +1,28 @@
 #include "HttpStatus.hpp"
 
-HttpStatus::StatusCode::StatusCode() : code_(HttpStatus::OK) {
+http::StatusCode::StatusCode() : code_(http::OK) {
 }
 
-HttpStatus::StatusCode::StatusCode(Status code) : code_(code) {
+http::StatusCode::StatusCode(Status code) : code_(code) {
 }
 
-HttpStatus::StatusCode::StatusCode(const StatusCode &other) : code_(other.code_) {
+http::StatusCode::StatusCode(const StatusCode &other) : code_(other.code_) {
 }
 
-HttpStatus::StatusCode &HttpStatus::StatusCode::operator=(const StatusCode &other) {
+http::StatusCode &http::StatusCode::operator=(const StatusCode &other) {
     if (this != &other) {
         code_ = other.code_;
     }
     return *this;
 }
 
-HttpStatus::Status HttpStatus::StatusCode::getCode() const {
+http::Status http::StatusCode::getCode() const {
     return code_;
 }
 
-const char *HttpStatus::StatusCode::getMessage() const {
+const char *http::StatusCode::getMessage() const {
     return statusMessage(code_);
 }
 
-HttpStatus::StatusCode::~StatusCode() {
+http::StatusCode::~StatusCode() {
 }

--- a/src/response/HttpStatus.cpp
+++ b/src/response/HttpStatus.cpp
@@ -1,0 +1,28 @@
+#include "HttpStatus.hpp"
+
+HttpStatus::StatusCode::StatusCode() : code_(HttpStatus::OK) {
+}
+
+HttpStatus::StatusCode::StatusCode(Status code) : code_(code) {
+}
+
+HttpStatus::StatusCode::StatusCode(const StatusCode &other) : code_(other.code_) {
+}
+
+HttpStatus::StatusCode &HttpStatus::StatusCode::operator=(const StatusCode &other) {
+    if (this != &other) {
+        code_ = other.code_;
+    }
+    return *this;
+}
+
+HttpStatus::Status HttpStatus::StatusCode::getCode() const {
+    return code_;
+}
+
+const char *HttpStatus::StatusCode::getMessage() const {
+    return statusMessage(code_);
+}
+
+HttpStatus::StatusCode::~StatusCode() {
+}

--- a/src/response/MimeTypes.cpp
+++ b/src/response/MimeTypes.cpp
@@ -1,0 +1,121 @@
+#define _POSIX_C_SOURCE 200809L
+#include "MimeTypes.hpp"
+#include <sstream>
+#include <fstream>
+
+MimeTypes::MimeTypes(const std::string &path): filePath_(path) {
+	mimeTypes_ = std::map<std::string, std::string>();
+	rtime_.tv_nsec = 0;
+	rtime_.tv_sec = 0;
+	reload();
+	if (mimeTypes_.empty())
+	{
+		throw std::runtime_error("Failed to load MIME types from file: " + filePath_);
+	}
+}
+
+MimeTypes::MimeTypes(const MimeTypes &other) {
+	mimeTypes_ = other.mimeTypes_;
+	filePath_ = other.filePath_;
+	rtime_ = other.rtime_;
+}
+
+MimeTypes &MimeTypes::operator=(const MimeTypes &other) {
+	if (this != &other) {
+		mimeTypes_ = other.mimeTypes_;
+		filePath_ = other.filePath_;
+		rtime_ = other.rtime_;
+	}
+	return *this;
+}
+
+const std::string MimeTypes::getMimeType(const std::string &extension) {
+	reload();
+	if (mimeTypes_.size() == 0)
+	{
+		return "text/plain";
+	}
+	std::map<std::string, std::string>::const_iterator it = mimeTypes_.find(extension);
+	if (it != mimeTypes_.end()) {
+		return it->second;
+	}
+	return "text/plain";
+}
+
+bool MimeTypes::wasChanged() {
+	struct stat fileStat;
+	if (stat(filePath_.c_str(), &fileStat) == 0) {
+		if (fileStat.st_mtim.tv_nsec != rtime_.tv_nsec
+			|| fileStat.st_mtim.tv_sec != rtime_.tv_sec) {
+			rtime_ = fileStat.st_mtim;
+			return true;
+		}
+	}
+    return false;
+}
+
+void MimeTypes::reload() {
+	if (!wasChanged())
+	{
+		return ;
+	}
+    std::ifstream file(filePath_.c_str());
+    std::string fileText;
+	std::ofstream out("config/mimes.types");
+    // Read the MIME types file line by line
+    // and check if the extension matches any of the defined types
+    if (file && out) {
+		mimeTypes_.clear();
+        while (std::getline(file, fileText)) {
+			//skip comments
+			if (fileText.find_first_of('#') == 0)
+			{
+				continue;
+			}
+			
+            std::string mimeType = fileText.substr(0, findFirstSpace(fileText));
+            std::string extensions = fileText.substr(findFirstNonSpace(fileText, mimeType.size()));
+			std::istringstream iss(extensions);
+            std::string ext;
+            while (iss >> ext) {
+				// mimeTypes_.insert(std::make_pair(ext, mimeType));
+				mimeTypes_[ext] = mimeType;
+				out << "[" << ext << "] " << "[" << mimeType << "]" << std::endl;
+            }
+        }
+    }
+}
+
+size_t MimeTypes::findFirstSpace(const std::string str) {
+	size_t pos = 0;
+	size_t size = str.size();
+	const char* tmp = str.c_str();
+	while (pos < size)
+	{
+		if (tmp[pos] == ' ' || tmp[pos] == '\t' || tmp[pos] == '\v')
+		{
+			return pos;
+		}
+		pos++;
+	}
+    return pos;
+}
+
+size_t MimeTypes::findFirstNonSpace(const std::string str, size_t startPos) {
+	size_t pos = startPos;
+	size_t size = str.size();
+	const char* tmp = str.c_str();
+	while (pos < size)
+	{
+		if (tmp[pos] != ' ' && tmp[pos] != '\t' && tmp[pos] != '\v')
+		{
+			return pos;
+		}
+		pos++;
+	}
+    return pos;
+}
+
+MimeTypes::~MimeTypes() {
+
+}

--- a/src/response/Response.cpp
+++ b/src/response/Response.cpp
@@ -1,6 +1,6 @@
 #include "Response.hpp"
 
-Response::Response()
+http::Response::Response()
     : httpVersion_("HTTP/1.1"), connectionType_("close"), statusCode_(http::OK), content_() {
     buildResponseStream();
 }

--- a/src/response/Response.cpp
+++ b/src/response/Response.cpp
@@ -1,12 +1,12 @@
 #include "Response.hpp"
 
 Response::Response()
-    : httpVersion_("HTTP/1.1"), connectionType_("close"), statusCode_(HttpStatus::OK), content_() {
+    : httpVersion_("HTTP/1.1"), connectionType_("close"), statusCode_(http::OK), content_() {
     buildResponseStream();
 }
 
 Response::Response(const std::string &httpVersion, const std::string &connectionType,
-                   const HttpStatus::StatusCode &statusCode, const ResponseContent &content)
+                   const http::StatusCode &statusCode, const ResponseContent &content)
     : httpVersion_(httpVersion), connectionType_(connectionType), statusCode_(statusCode),
       content_(content) {
     buildResponseStream();
@@ -37,7 +37,7 @@ const ResponseContent &Response::getContent() const {
     return content_;
 }
 
-const HttpStatus::StatusCode &Response::getStatusCode() const {
+const http::StatusCode &Response::getStatusCode() const {
     return statusCode_;
 }
 

--- a/src/response/Response.cpp
+++ b/src/response/Response.cpp
@@ -1,0 +1,59 @@
+#include "Response.hpp"
+
+Response::Response()
+    : httpVersion_("HTTP/1.1"), connectionType_("close"), statusCode_(HttpStatus::OK), content_() {
+    buildResponseStream();
+}
+
+Response::Response(const std::string &httpVersion, const std::string &connectionType,
+                   const HttpStatus::StatusCode &statusCode, const ResponseContent &content)
+    : httpVersion_(httpVersion), connectionType_(connectionType), statusCode_(statusCode),
+      content_(content) {
+    buildResponseStream();
+}
+
+Response::Response(const Response &other)
+    : httpVersion_(other.httpVersion_), connectionType_(other.connectionType_),
+      statusCode_(other.statusCode_), content_(other.content_) {
+    buildResponseStream();
+}
+
+Response &Response::operator=(const Response &other) {
+    if (this != &other) {
+        httpVersion_ = other.httpVersion_;
+        connectionType_ = other.connectionType_;
+        statusCode_ = other.statusCode_;
+        content_ = other.content_;
+        buildResponseStream();
+    }
+    return *this;
+}
+
+const std::string &Response::getHttpVersion() const {
+    return httpVersion_;
+}
+
+const ResponseContent &Response::getContent() const {
+    return content_;
+}
+
+const HttpStatus::StatusCode &Response::getStatusCode() const {
+    return statusCode_;
+}
+
+std::string Response::toString() const {
+    return respStream_.str();
+}
+
+Response::~Response() {
+}
+
+void Response::buildResponseStream() {
+    respStream_ << httpVersion_ << " " << statusCode_.getCode() << " " << statusCode_.getMessage()
+                << "\r\n"
+                << "Content-Type: " << content_.getType() << "\r\n"
+                << "Content-Length: " << content_.getContentLength() << "\r\n"
+                << "Connection: " << connectionType_ << "\r\n"
+                << "\r\n"
+                << content_.getBody();
+}

--- a/src/response/Response.cpp
+++ b/src/response/Response.cpp
@@ -5,20 +5,20 @@ http::Response::Response()
     buildResponseStream();
 }
 
-Response::Response(const std::string &httpVersion, const std::string &connectionType,
-                   const http::StatusCode &statusCode, const ResponseContent &content)
+http::Response::Response(const std::string &httpVersion, const std::string &connectionType,
+                   const http::StatusCode &statusCode, const http::ResponseContent &content)
     : httpVersion_(httpVersion), connectionType_(connectionType), statusCode_(statusCode),
       content_(content) {
     buildResponseStream();
 }
 
-Response::Response(const Response &other)
+http::Response::Response(const http::Response &other)
     : httpVersion_(other.httpVersion_), connectionType_(other.connectionType_),
       statusCode_(other.statusCode_), content_(other.content_) {
     buildResponseStream();
 }
 
-Response &Response::operator=(const Response &other) {
+http::Response &http::Response::operator=(const http::Response &other) {
     if (this != &other) {
         httpVersion_ = other.httpVersion_;
         connectionType_ = other.connectionType_;
@@ -29,26 +29,26 @@ Response &Response::operator=(const Response &other) {
     return *this;
 }
 
-const std::string &Response::getHttpVersion() const {
+const std::string &http::Response::getHttpVersion() const {
     return httpVersion_;
 }
 
-const ResponseContent &Response::getContent() const {
+const http::ResponseContent &http::Response::getContent() const {
     return content_;
 }
 
-const http::StatusCode &Response::getStatusCode() const {
+const http::StatusCode &http::Response::getStatusCode() const {
     return statusCode_;
 }
 
-std::string Response::toString() const {
+std::string http::Response::toString() const {
     return respStream_.str();
 }
 
-Response::~Response() {
+http::Response::~Response() {
 }
 
-void Response::buildResponseStream() {
+void http::Response::buildResponseStream() {
     respStream_.str(""); // Clear the stream
     respStream_ << httpVersion_ << " " << statusCode_.getCode() << " " << statusCode_.getMessage()
                 << "\r\n"

--- a/src/response/Response.cpp
+++ b/src/response/Response.cpp
@@ -49,6 +49,7 @@ Response::~Response() {
 }
 
 void Response::buildResponseStream() {
+    respStream_.str(""); // Clear the stream
     respStream_ << httpVersion_ << " " << statusCode_.getCode() << " " << statusCode_.getMessage()
                 << "\r\n"
                 << "Content-Type: " << content_.getType() << "\r\n"

--- a/src/response/ResponseBuilder.cpp
+++ b/src/response/ResponseBuilder.cpp
@@ -1,0 +1,80 @@
+#include "ResponseBuilder.hpp"
+#include "ServerBlock.hpp"
+#include "ServerConfig.hpp"
+#include "HttpStatus.hpp"
+#include <unistd.h>
+#include <errno.h>
+#include <iostream>
+
+const char *defaultErrorFile = "errorpage.html";
+
+bool ResponseBuilder::errorHandling(const std::string &httpVersion,
+                                    const std::string &connectionType,
+                                    const std::string &filePath) {
+
+    if (errno == ENOENT) {
+        return buildError(httpVersion, connectionType, http::NOT_FOUND, filePath);
+    }
+    if (errno == EACCES) {
+        return buildError(httpVersion, connectionType, http::FORBIDDEN, filePath);
+    }
+    return buildError(httpVersion, connectionType, http::INTERNAL_SERVER_ERROR, filePath);
+}
+
+ResponseBuilder::ResponseBuilder() {
+    serverBlockSet_ = false;
+}
+
+ResponseBuilder::ResponseBuilder(int port, const std::string &server_name,
+                                 const config::ServerConfig &serverConfig) {
+    if (!serverConfig.getServer(port, server_name, serverBlock_)) {
+        serverBlockSet_ = false;
+        return;
+    }
+    serverBlockSet_ = true;
+}
+
+bool ResponseBuilder::build(const std::string &httpVersion, const std::string &connectionType,
+                            const std::string &method, const std::string &filePath,
+                            const std::string &filename) {
+    if (!serverBlockSet_) {
+        std::cerr << "Server block not set. Cannot build response." << std::endl;
+        return false;
+    }
+    if (method == "GET") {
+        std::cout << "Building GET response for file: " << filePath << "/" << filename << std::endl;
+        return buildGetFile(httpVersion, connectionType, filePath, filename);
+    }
+    std::cerr << "Unsupported method: " << method << std::endl;
+    return false;
+}
+
+bool ResponseBuilder::buildGetFile(const std::string &httpVersion,
+                                   const std::string &connectionType, const std::string &dirPath,
+                                   const std::string &filename) {
+    const config::LocationBlock *block = serverBlock_->getLocation("/" + filename);
+    if (!block) {
+        std::cerr << "No matching location block for path: " << "/" << filename << std::endl;
+        return buildError(httpVersion, connectionType, http::NOT_FOUND, defaultErrorFile);
+    }
+
+
+        std::string fullPath = dirPath + "/" + filename;
+    if (access(fullPath.c_str(), R_OK) == -1) {
+        return errorHandling(httpVersion, connectionType, fullPath);
+    }
+    response_ = Response(httpVersion, connectionType,
+                         http::StatusCode(http::OK),
+                         ResponseContent(fullPath.c_str()));
+    return true;
+}
+
+bool ResponseBuilder::buildError(const std::string &httpVersion, const std::string &connectionType,
+                                 const http::Status &status, const std::string &filePath) {
+    response_ = Response(httpVersion, connectionType, http::StatusCode(status), ResponseContent(filePath.c_str()));
+    return true;
+}
+
+const Response &ResponseBuilder::getResponse() const {
+    return response_;
+}

--- a/src/response/ResponseBuilder.cpp
+++ b/src/response/ResponseBuilder.cpp
@@ -58,23 +58,22 @@ bool ResponseBuilder::buildGetFile(const std::string &httpVersion,
         return buildError(httpVersion, connectionType, http::NOT_FOUND, defaultErrorFile);
     }
 
-
-        std::string fullPath = dirPath + "/" + filename;
+    std::string fullPath = dirPath + "/" + filename;
     if (access(fullPath.c_str(), R_OK) == -1) {
         return errorHandling(httpVersion, connectionType, fullPath);
     }
-    response_ = Response(httpVersion, connectionType,
-                         http::StatusCode(http::OK),
-                         ResponseContent(fullPath.c_str()));
+    response_ = http::Response(httpVersion, connectionType, http::StatusCode(http::OK),
+                               http::ResponseContent(fullPath.c_str()));
     return true;
 }
 
 bool ResponseBuilder::buildError(const std::string &httpVersion, const std::string &connectionType,
                                  const http::Status &status, const std::string &filePath) {
-    response_ = Response(httpVersion, connectionType, http::StatusCode(status), ResponseContent(filePath.c_str()));
+    response_ = http::Response(httpVersion, connectionType, http::StatusCode(status),
+                               http::ResponseContent(filePath.c_str()));
     return true;
 }
 
-const Response &ResponseBuilder::getResponse() const {
+const http::Response &ResponseBuilder::getResponse() const {
     return response_;
 }

--- a/src/response/ResponseContent.cpp
+++ b/src/response/ResponseContent.cpp
@@ -1,0 +1,81 @@
+#include "ResponseContent.hpp"
+#include <fstream>
+#include <sstream>
+
+static std::string toLower(const std::string &s) {
+    std::string r = s;
+    for (std::string::size_type i = 0; i < r.size(); ++i)
+        r[i] = static_cast<char>(std::tolower(static_cast<unsigned char>(r[i])));
+    return r;
+}
+
+ResponseContent::ResponseContent() : body_(""), type_("") {
+}
+
+ResponseContent::ResponseContent(const char *path) {
+    std::ifstream file(path);
+    std::string fileText;
+    if (file) {
+        while (std::getline(file, fileText)) {
+            body_ += fileText;
+        }
+        setFileType(path);
+    }
+}
+
+ResponseContent::ResponseContent(const std::string &body, const std::string &type)
+    : body_(body), type_(type) {
+}
+
+ResponseContent::ResponseContent(const ResponseContent &other)
+    : body_(other.body_), type_(other.type_) {
+}
+
+ResponseContent &ResponseContent::operator=(const ResponseContent &other) {
+    if (this != &other) {
+        body_ = other.body_;
+        type_ = other.type_;
+    }
+    return *this;
+}
+
+const std::string &ResponseContent::getBody() const {
+    return body_;
+}
+
+const std::string &ResponseContent::getType() const {
+    return type_;
+}
+
+size_t ResponseContent::getContentLength() const {
+    return body_.size();
+}
+
+ResponseContent::~ResponseContent() {
+}
+
+void ResponseContent::setFileType(const std::string &path) {
+    size_t pos = path.find_last_of('.');
+    if (pos != std::string::npos) {
+        std::string extension = toLower(path.substr(pos + 1));
+        std::ifstream file(MIME_TYPES_PATH);
+        std::string fileText;
+        // Read the MIME types file line by line
+        // and check if the extension matches any of the defined types
+        if (file) {
+            while (std::getline(file, fileText)) {
+                std::string mimeType = fileText.substr(0, fileText.find_first_of(' '));
+                std::string extensions = fileText.substr(fileText.find_first_of(' ') + 1);
+                std::istringstream iss(extensions);
+                std::string ext;
+                while (iss >> ext) {
+                    if (extension == ext) {
+                        type_ = mimeType;
+                        return;
+                    }
+                }
+            }
+        }
+    }
+    type_ = "text/plain"; // Default MIME type if no match is found
+}

--- a/src/response/ResponseContent.cpp
+++ b/src/response/ResponseContent.cpp
@@ -9,10 +9,10 @@ static std::string toLower(const std::string &s) {
     return r;
 }
 
-ResponseContent::ResponseContent() : body_(""), type_("") {
+http::ResponseContent::ResponseContent() : body_(""), type_("") {
 }
 
-ResponseContent::ResponseContent(const char *path) {
+http::ResponseContent::ResponseContent(const char *path) {
     std::ifstream file(path);
     std::string fileText;
     if (file) {
@@ -23,15 +23,15 @@ ResponseContent::ResponseContent(const char *path) {
     }
 }
 
-ResponseContent::ResponseContent(const std::string &body, const std::string &type)
+http::ResponseContent::ResponseContent(const std::string &body, const std::string &type)
     : body_(body), type_(type) {
 }
 
-ResponseContent::ResponseContent(const ResponseContent &other)
+http::ResponseContent::ResponseContent(const http::ResponseContent &other)
     : body_(other.body_), type_(other.type_) {
 }
 
-ResponseContent &ResponseContent::operator=(const ResponseContent &other) {
+http::ResponseContent &http::ResponseContent::operator=(const http::ResponseContent &other) {
     if (this != &other) {
         body_ = other.body_;
         type_ = other.type_;
@@ -39,22 +39,22 @@ ResponseContent &ResponseContent::operator=(const ResponseContent &other) {
     return *this;
 }
 
-const std::string &ResponseContent::getBody() const {
+const std::string &http::ResponseContent::getBody() const {
     return body_;
 }
 
-const std::string &ResponseContent::getType() const {
+const std::string &http::ResponseContent::getType() const {
     return type_;
 }
 
-size_t ResponseContent::getContentLength() const {
+size_t http::ResponseContent::getContentLength() const {
     return body_.size();
 }
 
-ResponseContent::~ResponseContent() {
+http::ResponseContent::~ResponseContent() {
 }
 
-void ResponseContent::setFileType(const std::string &path) {
+void http::ResponseContent::setFileType(const std::string &path) {
     size_t pos = path.find_last_of('.');
     if (pos != std::string::npos) {
         std::string extension = toLower(path.substr(pos + 1));

--- a/src/response/ResponseSend.cpp
+++ b/src/response/ResponseSend.cpp
@@ -4,7 +4,7 @@
 #include <sys/socket.h>
 #include <iostream>
 
-bool ResponseSend::sendAll(int clientFd, const Response &response) {
+bool ResponseSend::sendAll(int clientFd, const http::Response &response) {
     return sendAll(clientFd, response.toString());
 }
 
@@ -14,12 +14,12 @@ bool ResponseSend::sendAll(int clientFd, const std::string &data) {
     const char *buf = data.c_str();
     while (sent < responseSize) {
         ssize_t n = send(clientFd, buf + sent, responseSize - sent,
-                #ifdef MSG_NOSIGNAL
-                    MSG_NOSIGNAL
-                #else
-                    0
-                #endif
-            );
+#ifdef MSG_NOSIGNAL
+                         MSG_NOSIGNAL
+#else
+                         0
+#endif
+        );
         if (n <= 0)
             return false;
         sent += static_cast<size_t>(n);

--- a/src/response/ResponseSend.cpp
+++ b/src/response/ResponseSend.cpp
@@ -1,0 +1,48 @@
+#include "ResponseSend.hpp"
+#include <unistd.h>
+#include <errno.h>
+#include <sys/socket.h>
+#include <iostream>
+
+bool ResponseSend::sendAll(int clientFd, const Response &response) {
+    return sendAll(clientFd, response.toString());
+}
+
+bool ResponseSend::sendAll(int clientFd, const std::string &data) {
+    size_t sent = 0;
+    size_t responseSize = data.size();
+    const char *buf = data.c_str();
+    while (sent < responseSize) {
+        ssize_t n = send(clientFd, buf + sent, responseSize - sent,
+                #ifdef MSG_NOSIGNAL
+                    MSG_NOSIGNAL
+                #else
+                    0
+                #endif
+            );
+        if (n <= 0)
+            return false;
+        sent += static_cast<size_t>(n);
+    }
+    return true;
+}
+
+long ResponseSend::sendSome(int clientFd, const std::string &data) {
+    errno = 0; // Reset errno before send
+    ssize_t sent = 0;
+    sent = send(clientFd, data.c_str(), data.size(),
+#ifdef MSG_NOSIGNAL
+                MSG_NOSIGNAL
+#else
+                0
+#endif
+    );
+    if (sent < 0) { // Handle specific errors
+        if (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK)
+            return 0; // Non-blocking send, try again later
+        return -1;    // Other errors, return -1 to indicate failure
+    }
+    if (sent == 0)
+        return -1; // No data sent, return -1 to indicate failure
+    return static_cast<long>(sent);
+}

--- a/tests/ResponseBuilderTest.cpp
+++ b/tests/ResponseBuilderTest.cpp
@@ -1,0 +1,104 @@
+// tests/test_response_builder.cpp
+#include "doctest.h"
+
+#include <fstream>
+#include <cstdio>
+#include <cstdlib>
+#include <cerrno>
+#include <sys/stat.h>
+#include <cstring>
+
+#include "ResponseBuilder.hpp"   // твій хедер
+#include "Response.hpp"
+#include "HttpStatus.hpp"
+#include "ServerConfig.hpp"
+
+TEST_CASE("buildError: returns proper status and loads body from file") {
+    const std::string tmp =  "test_tmp_dir";
+    const std::string errfile = "test_tmp_dir/errorpage.html";
+
+    config::ServerConfig cfg("/home/ogrativ/projects/ServerX/config/example.conf"); // не використовується тут, але потрібен для ctor
+    ResponseBuilder rb(/*port*/9191, /*server_name*/"localhost", cfg);
+
+    bool ok = rb.buildError("HTTP/1.1", "close", http::NOT_FOUND, errfile);
+    CHECK(ok);
+
+    const Response& resp = rb.getResponse();
+    const std::string wire = resp.toString();
+
+	CHECK(resp.getStatusCode().getCode() == http::NOT_FOUND);
+	std::string message = resp.getStatusCode().getMessage();
+	CHECK(strcmp(message.c_str(), "Not Found") == 0);
+}
+
+TEST_CASE("buildGetFile: returns 200 for existing index file") {
+    const std::string tmp =  "test_tmp_dir";
+
+    config::ServerConfig cfg("/home/ogrativ/projects/ServerX/config/example.conf");
+
+    ResponseBuilder rb(/*port*/9191, /*server_name*/"localhost", cfg);
+
+    // bool ok = rb.buildGetFile("HTTP/1.1", "close", /*dirPath*/tmp + "/", /*filename*/"index.html");
+	bool ok = rb.build("HTTP/1.1", "close", "GET", /*dirPath*/tmp, /*filename*/"index.html");
+    CHECK(ok);
+
+	 const Response& resp = rb.getResponse();
+	 std::string message = resp.getStatusCode().getMessage();
+	 
+	CHECK(resp.getStatusCode().getCode() == http::OK);
+	CHECK(strcmp(message.c_str(), "OK") == 0);
+}
+
+// TEST_CASE("buildGetFile: returns 403 when requested filename is not in index list (directory request)") {
+//     const std::string tmp = make_tmp_dir();
+//     write_file(tmp, "home.html", "<p>Home</p>");
+
+//     config::ServerConfig cfg;
+//     cfg.block.loc.root = tmp + "/";
+//     cfg.block.loc.index.push_back("index.html"); // home.html тут НІ
+//     cfg.block.loc.autoindex = false;
+
+//     ResponseBuilder rb(/*port*/80, /*server_name*/"localhost", cfg);
+
+//     bool ok = rb.buildGetFile("HTTP/1.1", "close", /*dirPath*/tmp + "/", /*filename*/"home.html");
+//     CHECK(ok); // buildGetFile повертає true бо зібрав error-відповідь; якщо повертає false — змінюй на CHECK(!ok)
+
+//     const std::string wire = rb.getResponse().toString();
+//     CHECK(extract_status_code(wire) == 403); // ти саме щойно поміняв на FORBIDDEN
+// }
+
+// TEST_CASE("buildGetFile: returns 404 when file does not exist") {
+//     const std::string tmp = make_tmp_dir();
+
+//     config::ServerConfig cfg;
+//     cfg.block.loc.root = tmp + "/";
+//     cfg.block.loc.index.push_back("index.html");
+//     cfg.block.loc.autoindex = false;
+
+//     ResponseBuilder rb(/*port*/80, /*server_name*/"localhost", cfg);
+
+//     bool ok = rb.buildGetFile("HTTP/1.1", "close", /*dirPath*/tmp + "/", /*filename*/"index.html");
+//     CHECK(ok);
+
+//     const std::string wire = rb.getResponse().toString();
+//     CHECK(extract_status_code(wire) == 404); // немає index.html → 404 (або 403, залежно від твоєї логіки)
+// }
+
+// TEST_CASE("build: GET dispatches to buildGetFile and produces 200 for existing index") {
+//     const std::string tmp = make_tmp_dir();
+//     write_file(tmp, "index.html", "<p>OK!</p>");
+
+//     config::ServerConfig cfg;
+//     cfg.block.loc.root = tmp + "/";
+//     cfg.block.loc.index.push_back("index.html");
+//     cfg.block.loc.autoindex = false;
+
+//     ResponseBuilder rb(/*port*/80, /*server_name*/"localhost", cfg);
+
+//     bool ok = rb.build("HTTP/1.1", "close", "GET", /*dirPath*/tmp + "/", /*filename*/"index.html");
+//     CHECK(ok);
+
+//     const std::string wire = rb.getResponse().toString();
+//     CHECK(extract_status_code(wire) == 200);
+//     CHECK(body_contains(wire, "OK!"));
+// }

--- a/tests/ResponseBuilderTest.cpp
+++ b/tests/ResponseBuilderTest.cpp
@@ -17,13 +17,13 @@ TEST_CASE("buildError: returns proper status and loads body from file") {
     const std::string tmp =  "test_tmp_dir";
     const std::string errfile = "test_tmp_dir/errorpage.html";
 
-    config::ServerConfig cfg("/home/ogrativ/projects/ServerX/config/example.conf"); // не використовується тут, але потрібен для ctor
+    config::ServerConfig cfg("config/example.conf");
     ResponseBuilder rb(/*port*/9191, /*server_name*/"localhost", cfg);
 
     bool ok = rb.buildError("HTTP/1.1", "close", http::NOT_FOUND, errfile);
     CHECK(ok);
 
-    const Response& resp = rb.getResponse();
+    const http::Response& resp = rb.getResponse();
     const std::string wire = resp.toString();
 
 	CHECK(resp.getStatusCode().getCode() == http::NOT_FOUND);
@@ -34,7 +34,7 @@ TEST_CASE("buildError: returns proper status and loads body from file") {
 TEST_CASE("buildGetFile: returns 200 for existing index file") {
     const std::string tmp =  "test_tmp_dir";
 
-    config::ServerConfig cfg("/home/ogrativ/projects/ServerX/config/example.conf");
+    config::ServerConfig cfg("config/example.conf");
 
     ResponseBuilder rb(/*port*/9191, /*server_name*/"localhost", cfg);
 
@@ -42,7 +42,7 @@ TEST_CASE("buildGetFile: returns 200 for existing index file") {
 	bool ok = rb.build("HTTP/1.1", "close", "GET", /*dirPath*/tmp, /*filename*/"index.html");
     CHECK(ok);
 
-	 const Response& resp = rb.getResponse();
+	 const http::Response& resp = rb.getResponse();
 	 std::string message = resp.getStatusCode().getMessage();
 	 
 	CHECK(resp.getStatusCode().getCode() == http::OK);

--- a/tests/ResponseContentTest.cpp
+++ b/tests/ResponseContentTest.cpp
@@ -38,94 +38,94 @@ static void writeMimeFile(const std::string& content, const char* path) {
 }
 
 static void test_basic_two_column() {
-    ResponseContent rc;
+    http::ResponseContent rc;
 
 	writeMimeFile("<!DOCTYPE html><html><head><title>Example</title></head><body><p>This is an example of a simple HTML page with one paragraph.</p></body></html>", "test_files/index.html");
-    rc = ResponseContent("test_files/index.html");
+    rc = http::ResponseContent("test_files/index.html");
     CHECK(mimeTypeCheck(rc.getType(), "text/html"));
 
     writeMimeFile("test_files/style.css", "test_files/style.css");
-    rc = ResponseContent("test_files/style.css");
+    rc = http::ResponseContent("test_files/style.css");
     CHECK(mimeTypeCheck(rc.getType(), "text/css"));
 
     writeMimeFile("test_files/photo.jpg", "test_files/photo.jpg");
-    rc = ResponseContent("test_files/photo.jpg");
+    rc = http::ResponseContent("test_files/photo.jpg");
     CHECK(mimeTypeCheck(rc.getType(), "image/jpeg"));
 
     writeMimeFile("test_files/README", "test_files/README");
-    rc = ResponseContent("test_files/README");
+    rc = http::ResponseContent("test_files/README");
     CHECK(mimeTypeCheck(rc.getType(), DEFAULT_MIME_TYPE));
 
     writeMimeFile("test_files/.bashrc", "test_files/.bashrc");
-    rc = ResponseContent("test_files/.bashrc");
+    rc = http::ResponseContent("test_files/.bashrc");
     CHECK(mimeTypeCheck(rc.getType(), DEFAULT_MIME_TYPE));
 
     writeMimeFile("test_files/weird.", "test_files/weird.");
-    rc = ResponseContent("test_files/weird.");
+    rc = http::ResponseContent("test_files/weird.");
     CHECK(mimeTypeCheck(rc.getType(), DEFAULT_MIME_TYPE));
 }
 
 static void test_whitespace_tabs_comments() {
 
-    ResponseContent rc;
+    http::ResponseContent rc;
 
     writeMimeFile("test_files/anim.gif", "test_files/anim.gif");
-    rc = ResponseContent("test_files/anim.gif");
+    rc = http::ResponseContent("test_files/anim.gif");
     CHECK(mimeTypeCheck(rc.getType(), "image/gif"));
 
     writeMimeFile("test_files/data.json", "test_files/data.json");
-    rc = ResponseContent("test_files/data.json");
+    rc = http::ResponseContent("test_files/data.json");
     CHECK(mimeTypeCheck(rc.getType(), "application/json"));
 
     writeMimeFile("test_files/note.TXT", "test_files/note.TXT");
-    rc = ResponseContent("test_files/note.TXT");
+    rc = http::ResponseContent("test_files/note.TXT");
     CHECK(mimeTypeCheck(rc.getType(), "text/plain"));
 }
 
 static void test_multiple_exts_in_one_line() {
 
-    ResponseContent rc;
+    http::ResponseContent rc;
 
     writeMimeFile("test_files/script.js", "test_files/script.js");
-    rc = ResponseContent("test_files/script.js");
+    rc = http::ResponseContent("test_files/script.js");
     CHECK(mimeTypeCheck(rc.getType(), "application/javascript"));
 
 	writeMimeFile("test_files/module.mjs", "test_files/module.mjs");
-    rc = ResponseContent("test_files/module.mjs");
+    rc = http::ResponseContent("test_files/module.mjs");
     CHECK(mimeTypeCheck(rc.getType(), "application/javascript"));
 
 	writeMimeFile("test_files/photo.jpeg", "test_files/photo.jpeg");
-    rc = ResponseContent("test_files/photo.jpeg");
+    rc = http::ResponseContent("test_files/photo.jpeg");
     CHECK(mimeTypeCheck(rc.getType(), "image/jpeg"));
 
 	writeMimeFile("test_files/vector.svg", "test_files/vector.svg");
-    rc = ResponseContent("test_files/vector.svg");
+    rc = http::ResponseContent("test_files/vector.svg");
     CHECK(mimeTypeCheck(rc.getType(), "image/svg+xml"));
 }
 
 static void test_leading_dot_in_mapping() {
 
-    ResponseContent rc;
+    http::ResponseContent rc;
 
 	writeMimeFile("test_files/icon.PNG", "test_files/icon.PNG");
-    rc = ResponseContent("test_files/icon.PNG");
+    rc = http::ResponseContent("test_files/icon.PNG");
     CHECK(mimeTypeCheck(rc.getType(), "image/png"));
 
 	writeMimeFile("test_files/report.pdf", "test_files/report.pdf");
-    rc = ResponseContent("test_files/report.pdf");
+    rc = http::ResponseContent("test_files/report.pdf");
     CHECK(mimeTypeCheck(rc.getType(), "application/pdf"));
 }
 
 static void test_unknown_extension_defaults() {
 
-    ResponseContent rc;
+    http::ResponseContent rc;
 
 	writeMimeFile("test_files/archive.xyz", "test_files/archive.xyz");
-    rc = ResponseContent("test_files/archive.xyz");
+    rc = http::ResponseContent("test_files/archive.xyz");
     CHECK(mimeTypeCheck(rc.getType(), DEFAULT_MIME_TYPE));
 
 	writeMimeFile("test_files/unknown.ext", "test_files/unknown.ext");
-    rc = ResponseContent("test_files/unknown.ext");
+    rc = http::ResponseContent("test_files/unknown.ext");
     CHECK(mimeTypeCheck(rc.getType(), DEFAULT_MIME_TYPE));
 }
 
@@ -169,7 +169,7 @@ TEST_CASE("testing the ResponseContent class") {
     test_leading_dot_in_mapping();
     test_unknown_extension_defaults();
 
-	ResponseContent rc("test_files/index.html");
+	http::ResponseContent rc("test_files/index.html");
 	CHECK(bodyCheck(rc.getBody(), "<!DOCTYPE html><html><head><title>Example</title></head><body><p>This is an example of a simple HTML page with one paragraph.</p></body></html>"));
 
 	removeRecursive("test_files"); // Clean up the test directory

--- a/tests/ResponseContentTest.cpp
+++ b/tests/ResponseContentTest.cpp
@@ -1,0 +1,176 @@
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <dirent.h>
+#include <iostream>
+#include <string>
+#include <sstream>
+#include <fstream>
+#include "ResponseContent.hpp"
+#include "doctest.h"
+
+const char* const DEFAULT_MIME_TYPE = "text/plain";
+
+bool mimeTypeCheck(const std::string& type, const std::string& expected) {
+    if (type != expected) {
+        std::cerr << "MIME type check failed at " << __FILE__ << ":" << __LINE__
+                  << "\n  actual:   [" << type << "]"
+                  << "\n  expected: [" << expected << "]\n";
+        return false;
+    }
+    return true;
+}
+
+bool bodyCheck(const std::string& body, const std::string& expected) {
+    if (body != expected) {
+        std::cerr << "Body check failed at " << __FILE__ << ":" << __LINE__
+                  << "\n  actual:   [" << body << "]"
+                  << "\n  expected: [" << expected << "]\n";
+        return false;
+    }
+    return true;
+}
+
+static void writeMimeFile(const std::string& content, const char* path) {
+    std::ofstream out(path);
+    out << content;
+    out.close();
+}
+
+static void test_basic_two_column() {
+    ResponseContent rc;
+
+	writeMimeFile("<!DOCTYPE html><html><head><title>Example</title></head><body><p>This is an example of a simple HTML page with one paragraph.</p></body></html>", "test_files/index.html");
+    rc = ResponseContent("test_files/index.html");
+    CHECK(mimeTypeCheck(rc.getType(), "text/html"));
+
+    writeMimeFile("test_files/style.css", "test_files/style.css");
+    rc = ResponseContent("test_files/style.css");
+    CHECK(mimeTypeCheck(rc.getType(), "text/css"));
+
+    writeMimeFile("test_files/photo.jpg", "test_files/photo.jpg");
+    rc = ResponseContent("test_files/photo.jpg");
+    CHECK(mimeTypeCheck(rc.getType(), "image/jpeg"));
+
+    writeMimeFile("test_files/README", "test_files/README");
+    rc = ResponseContent("test_files/README");
+    CHECK(mimeTypeCheck(rc.getType(), DEFAULT_MIME_TYPE));
+
+    writeMimeFile("test_files/.bashrc", "test_files/.bashrc");
+    rc = ResponseContent("test_files/.bashrc");
+    CHECK(mimeTypeCheck(rc.getType(), DEFAULT_MIME_TYPE));
+
+    writeMimeFile("test_files/weird.", "test_files/weird.");
+    rc = ResponseContent("test_files/weird.");
+    CHECK(mimeTypeCheck(rc.getType(), DEFAULT_MIME_TYPE));
+}
+
+static void test_whitespace_tabs_comments() {
+
+    ResponseContent rc;
+
+    writeMimeFile("test_files/anim.gif", "test_files/anim.gif");
+    rc = ResponseContent("test_files/anim.gif");
+    CHECK(mimeTypeCheck(rc.getType(), "image/gif"));
+
+    writeMimeFile("test_files/data.json", "test_files/data.json");
+    rc = ResponseContent("test_files/data.json");
+    CHECK(mimeTypeCheck(rc.getType(), "application/json"));
+
+    writeMimeFile("test_files/note.TXT", "test_files/note.TXT");
+    rc = ResponseContent("test_files/note.TXT");
+    CHECK(mimeTypeCheck(rc.getType(), "text/plain"));
+}
+
+static void test_multiple_exts_in_one_line() {
+
+    ResponseContent rc;
+
+    writeMimeFile("test_files/script.js", "test_files/script.js");
+    rc = ResponseContent("test_files/script.js");
+    CHECK(mimeTypeCheck(rc.getType(), "application/javascript"));
+
+	writeMimeFile("test_files/module.mjs", "test_files/module.mjs");
+    rc = ResponseContent("test_files/module.mjs");
+    CHECK(mimeTypeCheck(rc.getType(), "application/javascript"));
+
+	writeMimeFile("test_files/photo.jpeg", "test_files/photo.jpeg");
+    rc = ResponseContent("test_files/photo.jpeg");
+    CHECK(mimeTypeCheck(rc.getType(), "image/jpeg"));
+
+	writeMimeFile("test_files/vector.svg", "test_files/vector.svg");
+    rc = ResponseContent("test_files/vector.svg");
+    CHECK(mimeTypeCheck(rc.getType(), "image/svg+xml"));
+}
+
+static void test_leading_dot_in_mapping() {
+
+    ResponseContent rc;
+
+	writeMimeFile("test_files/icon.PNG", "test_files/icon.PNG");
+    rc = ResponseContent("test_files/icon.PNG");
+    CHECK(mimeTypeCheck(rc.getType(), "image/png"));
+
+	writeMimeFile("test_files/report.pdf", "test_files/report.pdf");
+    rc = ResponseContent("test_files/report.pdf");
+    CHECK(mimeTypeCheck(rc.getType(), "application/pdf"));
+}
+
+static void test_unknown_extension_defaults() {
+
+    ResponseContent rc;
+
+	writeMimeFile("test_files/archive.xyz", "test_files/archive.xyz");
+    rc = ResponseContent("test_files/archive.xyz");
+    CHECK(mimeTypeCheck(rc.getType(), DEFAULT_MIME_TYPE));
+
+	writeMimeFile("test_files/unknown.ext", "test_files/unknown.ext");
+    rc = ResponseContent("test_files/unknown.ext");
+    CHECK(mimeTypeCheck(rc.getType(), DEFAULT_MIME_TYPE));
+}
+
+bool removeRecursive(const std::string &path) {
+    DIR *dir = opendir(path.c_str());
+    if (!dir) return false;
+
+    struct dirent *entry;
+    while ((entry = readdir(dir)) != NULL) {
+        std::string name = entry->d_name;
+		// Skip the current and parent directory entries
+        if (name == "." || name == "..") continue;
+
+        std::string fullPath = path + "/" + name;
+        struct stat st;
+        if (stat(fullPath.c_str(), &st) == 0) {
+            if (S_ISDIR(st.st_mode)) {
+				// Recursively remove the directory
+                if (!removeRecursive(fullPath)) {
+                    closedir(dir);
+                    return false;
+                }
+            } else {
+				// Remove the file
+                if (unlink(fullPath.c_str()) != 0) {
+                    closedir(dir);
+                    return false;
+                }
+            }
+        }
+    }
+    closedir(dir);
+    return rmdir(path.c_str()) == 0;
+}
+
+TEST_CASE("testing the ResponseContent class") {
+	mkdir("test_files", 0777);
+    test_basic_two_column();
+    test_whitespace_tabs_comments();
+    test_multiple_exts_in_one_line();
+    test_leading_dot_in_mapping();
+    test_unknown_extension_defaults();
+
+	ResponseContent rc("test_files/index.html");
+	CHECK(bodyCheck(rc.getBody(), "<!DOCTYPE html><html><head><title>Example</title></head><body><p>This is an example of a simple HTML page with one paragraph.</p></body></html>"));
+
+	removeRecursive("test_files"); // Clean up the test directory
+}

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -1,0 +1,46 @@
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <dirent.h>
+#include <string>
+#include <fstream>
+#include <iostream>
+#include <cstring>
+
+bool removeDirectoryRecursive(const std::string &path) {
+    DIR *dir = opendir(path.c_str());
+    if (!dir) return false;
+
+    struct dirent *entry;
+    while ((entry = readdir(dir)) != NULL) {
+        std::string name = entry->d_name;
+		// Skip the current and parent directory entries
+        if (name == "." || name == "..") continue;
+
+        std::string fullPath = path + "/" + name;
+        struct stat st;
+        if (stat(fullPath.c_str(), &st) == 0) {
+            if (S_ISDIR(st.st_mode)) {
+				// Recursively remove the directory
+                if (!removeDirectoryRecursive(fullPath)) {
+                    closedir(dir);
+                    return false;
+                }
+            } else {
+				// Remove the file
+                if (unlink(fullPath.c_str()) != 0) {
+                    closedir(dir);
+                    return false;
+                }
+            }
+        }
+    }
+    closedir(dir);
+    return rmdir(path.c_str()) == 0;
+}
+
+void writeFile(const std::string& content, const char* path) {
+    std::ofstream out(path);
+    out << content;
+    out.close();
+}

--- a/tests/test_utils.hpp
+++ b/tests/test_utils.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <string>
+
+bool removeDirectoryRecursive(const std::string &path);
+
+void writeFile(const std::string& content, const char* path);


### PR DESCRIPTION
Description

This PR introduces the first version of the Response Builder, responsible for centralizing and standardizing HTTP responses across the service.
The goal is to unify success/error response formats and simplify API maintenance.

Changes

- Added ResponseBuilder class

- Implemented methods for:

    - building success responses (success)

    - building error responses (error)

- Added basic documentation

- Covered core scenarios with tests