### PR TITLE
docs(config): add documentation for upload_path and upload_file_size directives

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,3 +20,5 @@ which they can be used.
 | [`server_name`](./directives/server_name.md) | `server`             | Sets the names of the virtual server.        |
 | [`root`](./directives/root.md)               | `server`, `location` | Sets the root directory for requests.        |
 | [`index`](./directives/index.md)             | `location`           | ---                                          |
+| [`upload_path`](./directives/upload_path.md) | `location` | Sets the upload directory for incoming file requests. |
+| [`upload_file_size`](./directives/upload_file_size.md) | `server` | Defines the maximum allowed upload size in MiB. |

--- a/docs/directives/upload_file_size.md
+++ b/docs/directives/upload_file_size.md
@@ -1,0 +1,49 @@
+# Directive: upload_file_size
+
+Sets the maximum allowed file size (in MiB) for uploaded files.
+
+|             |                                   |
+| ----------- | --------------------------------- |
+| **Syntax**  | `upload_file_size [size_in_MiB];` |
+| **Default** | `---`                             |
+| **Context** | `server`                          |
+
+---
+
+## Description
+
+The `upload_file_size` directive limits the size of the uploaded file content.
+If the size specified in the `Content-Length` header exceeds this limit, the server responds with `413 Payload Too Large`.
+
+The size is expressed in mebibytes (MiB), where `1 MiB = 1,048,576 bytes`.
+
+If this directive is not specified, uploads are unrestricted by default.
+
+---
+
+## Examples
+
+### Example 1: Limit uploads to 10 MiB
+
+```nginx
+server {
+    upload_file_size 10;
+}
+```
+
+Any upload larger than 10 MiB will be rejected with `413 Payload Too Large`.
+
+### Example 2: Combined with upload_path
+
+```nginx
+server {
+
+    upload_file_size 5;
+
+    location /img/ {
+        upload_path img/uploads;
+    }
+}
+```
+
+Uploads to /img/ will be stored in img/uploads and limited to 5 MiB.

--- a/docs/directives/upload_path.md
+++ b/docs/directives/upload_path.md
@@ -1,0 +1,45 @@
+# Directive: upload_path
+
+Specifies the destination directory where uploaded files should be saved.
+
+|             |                                   |
+| ----------- | --------------------------------- |
+| **Syntax**  | `upload_path [path];`      |
+| **Default** | `---`                             |
+| **Context** | `location`                        |
+
+---
+
+## Description
+
+The `upload_path` directive defines the directory on the server’s filesystem where files received via POST requests should be stored.
+The path can be either absolute (starting with /) or relative to the server’s root directive.
+
+If the specified directory does not exist or is not writable by the server process, the upload will fail with an appropriate HTTP error (403 or 500).
+
+---
+
+## Examples
+
+### Example 1: Relative upload path (inside server root)
+
+```nginx
+server {
+    root /var/www/html;
+
+    location /img/ {
+        upload_path img/uploads;
+    }
+}
+```
+Uploaded files to /img/ will be stored in /var/www/html/img/uploads/.
+
+### Example 2: Absolute upload path
+
+```nginx
+location /upload/ {
+    upload_path /data/uploads;
+}
+```
+
+Files uploaded to /upload/ will be saved directly to /data/uploads/, regardless of the root setting.


### PR DESCRIPTION
### ✳️ New directives

- upload_path — defines the directory where uploaded files will be stored.

- upload_file_size — sets the maximum allowed upload size (in MiB).

### 📂 Changes

- Added: docs/directives/upload_path.md

- Added: docs/directives/upload_file_size.md

- Updated: configuration directives summary table in README.md

### 💡 Notes

- Follows the same structure and formatting as other configuration directive docs (e.g., index, root).

- Complements the recent feat(file upload) implementation.

- Helps maintainers and users correctly configure upload-related features.