### PR TITLE
feat(http): Add 3xx status codes and unify status utilities

### DIFF
--- a/inc/http/HttpStatus.hpp
+++ b/inc/http/HttpStatus.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 namespace http {
 
 /**
@@ -7,29 +9,41 @@ namespace http {
  * @brief Enumeration of common HTTP status codes.
  */
 enum HttpStatus {
-    OK = 200,         /** 200 OK — request succeeded. */
-    CREATED = 201,    /** 201 Created — resource created successfully. */
-    ACCEPTED = 202,   /** 202 Accepted — request accepted for processing, but not yet completed. */
-    NO_CONTENT = 204, /** 204 No Content — request succeeded, no response body. */
+    UNKNOWN_STATUS = 0,
 
-    BAD_REQUEST = 400,  /** 400 Bad Request — malformed request syntax or invalid parameters. */
-    UNAUTHORIZED = 401, /** 401 Unauthorized — authentication required or has failed. */
-    FORBIDDEN = 403, /** 403 Forbidden — client is authenticated but not permitted to perform this
-                        action. */
-    NOT_FOUND = 404, /** 404 Not Found — requested resource does not exist. */
-    METHOD_NOT_ALLOWED =
-        405,        /** 405 Method Not Allowed — HTTP method not permitted for this resource. */
-    CONFLICT = 409, /** 409 Conflict — request could not be completed due to a resource conflict
-                       (e.g., non-empty directory on DELETE). */
-    LENGTH_REQUIRED = 411,   /** 411 Length Required — missing Content-Length header for a request
-                                that requires it. */
-    PAYLOAD_TOO_LARGE = 413, /** 413 Payload Too Large — request body exceeds configured limit. */
-    UNSUPPORTED_MEDIA_TYPE = 415, /** 415 Unsupported Media Type — request entity format is not
-                                     supported by the server. */
+    // 2xx Success
+    OK = 200,         /** *Request succeeded. */
+    CREATED = 201,    /** *Resource created. */
+    ACCEPTED = 202,   /** Request accepted for processing. */
+    NO_CONTENT = 204, /** *Request succeeded; no body in response (e.g., DELETE). */
 
-    INTERNAL_SERVER_ERROR = 500, /** 500 Internal Server Error — generic server-side failure. */
-    NOT_IMPLEMENTED = 501        /** 501 Not Implemented — server does not support the functionality
-                                    required to fulfill the request. */
+    // 3xx Redirection
+    MOVED_PERMANENTLY = 301, /** *Resource moved to new URL (permanent). */
+    FOUND = 302,             /** *Resource temporarily at different URL. */
+    SEE_OTHER = 303,         /** See another URL (often used after POST). */
+    NOT_MODIFIED = 304,      /** Resource not modified since last access. */
+
+    // 4xx Client Error
+    BAD_REQUEST = 400,  /** *Malformed syntax or invalid parameters (client error). */
+    UNAUTHORIZED = 401, /** *Authentication failed or is missing (Unauthenticated). */
+    FORBIDDEN = 403,    /** *Client authenticated but not authorized for action (Unauthorized). */
+    NOT_FOUND = 404,    /** *Requested resource doesn't exist. */
+    METHOD_NOT_ALLOWED = 405,     /** *HTTP method not allowed for resource. */
+    CONFLICT = 409,               /** *Request failed due to resource conflict (e.g., duplicate). */
+    LENGTH_REQUIRED = 411,        /** Missing Content-Length header. */
+    PAYLOAD_TOO_LARGE = 413,      /** Request body exceeds limit. */
+    UNSUPPORTED_MEDIA_TYPE = 415, /** Request entity format is not supported. */
+
+    // 5xx Server Error
+    INTERNAL_SERVER_ERROR = 500, /** *Generic server-side failure. */
+    NOT_IMPLEMENTED = 501,       /** Server lacks functionality to fulfill request. */
+    BAD_GATEWAY = 502,           /** *Invalid response from upstream server (gateway/proxy). */
 };
+
+HttpStatus toHttpStatus(int);
+
+HttpStatus toHttpStatus(const std::string &codeStr);
+
+const char *getReasonPhrase(HttpStatus status);
 
 } // namespace http

--- a/src/http/Response.cpp
+++ b/src/http/Response.cpp
@@ -5,38 +5,6 @@
 
 namespace http {
 
-namespace {
-
-inline const char *getReasonPhrase(HttpStatus status) {
-    switch (status) {
-    case OK:
-        return "OK";
-    case CREATED:
-        return "Created";
-    case ACCEPTED:
-        return "Accepted";
-    case NO_CONTENT:
-        return "No Content";
-    case BAD_REQUEST:
-        return "Bad Request";
-    case UNAUTHORIZED:
-        return "Unauthorized";
-    case FORBIDDEN:
-        return "Forbidden";
-    case NOT_FOUND:
-        return "Not Found";
-    case METHOD_NOT_ALLOWED:
-        return "Method Not Allowed";
-    case INTERNAL_SERVER_ERROR:
-        return "Internal Server Error";
-    case PAYLOAD_TOO_LARGE:
-        return "Payload too large";
-    default:
-        return "Unknown";
-    }
-}
-} // namespace
-
 ResponseStartLine::ResponseStartLine() : protocol("HTTP/1.1"), statusCode(OK), reasonPhrase("OK") {}
 
 Response::Response() : body_(NULL) {}

--- a/src/http/internal/HttpStatus.cpp
+++ b/src/http/internal/HttpStatus.cpp
@@ -1,0 +1,84 @@
+#include "http/HttpStatus.hpp"
+#include <cstdlib>
+#include <string>
+
+namespace http {
+
+HttpStatus toHttpStatus(int code) {
+    switch (code) {
+        // clang-format off
+        // 2xx Success
+        case 200: return OK;
+        case 201: return CREATED;
+        case 202: return ACCEPTED;
+        case 204: return NO_CONTENT;
+        
+        // 3xx Redirection (NEW)
+        case 301: return MOVED_PERMANENTLY;
+        case 302: return FOUND;
+        case 303: return SEE_OTHER;
+        case 304: return NOT_MODIFIED;
+
+        // 4xx Client Error
+        case 400: return BAD_REQUEST;
+        case 401: return UNAUTHORIZED;
+        case 403: return FORBIDDEN;
+        case 404: return NOT_FOUND;
+        case 405: return METHOD_NOT_ALLOWED;
+        case 409: return CONFLICT;
+        case 411: return LENGTH_REQUIRED;
+        case 413: return PAYLOAD_TOO_LARGE;
+        case 415: return UNSUPPORTED_MEDIA_TYPE;
+        
+        // 5xx Server Error
+        case 500: return INTERNAL_SERVER_ERROR;
+        case 501: return NOT_IMPLEMENTED;
+        case 502: return BAD_GATEWAY;
+        
+        default: return UNKNOWN_STATUS;
+        // clang-format on
+    }
+}
+
+HttpStatus toHttpStatus(const std::string &codeStr) {
+    int code = std::atoi(codeStr.c_str());
+    return toHttpStatus(code);
+}
+
+const char *getReasonPhrase(HttpStatus status) {
+    switch (status) {
+        // clang-format off
+        // 2xx Success
+        case OK: return "OK";
+        case CREATED: return "Created";
+        case ACCEPTED: return "Accepted";
+        case NO_CONTENT: return "No Content";
+
+        // 3xx Redirection (NEW)
+        case MOVED_PERMANENTLY: return "Moved Permanently";
+        case FOUND: return "Found";
+        case SEE_OTHER: return "See Other";
+        case NOT_MODIFIED: return "Not Modified";
+
+        // 4xx Client Error
+        case BAD_REQUEST: return "Bad Request";
+        case UNAUTHORIZED: return "Unauthorized";
+        case FORBIDDEN: return "Forbidden";
+        case NOT_FOUND: return "Not Found";
+        case METHOD_NOT_ALLOWED: return "Method Not Allowed";
+        case CONFLICT: return "Conflict";
+        case LENGTH_REQUIRED: return "Length Required";
+        case PAYLOAD_TOO_LARGE: return "Payload Too Large";
+        case UNSUPPORTED_MEDIA_TYPE: return "Unsupported Media Type";
+        
+        // 5xx Server Error
+        case INTERNAL_SERVER_ERROR: return "Internal Server Error";
+        case NOT_IMPLEMENTED: return "Not Implemented";
+        case BAD_GATEWAY: return "Bad Gateway";
+        
+        default: return "Unknown Status";
+        // clang-format on
+    }
+}
+
+} // namespace http


### PR DESCRIPTION
Add support for common 3xx (Redirection) status codes to the HttpStatus enum and related utility functions (toHttpStatus).

Refactor:
- Added 301, 302, 303, and 304 to the enum and mapping functions.
- Moved getReasonPhrase from Respone.hpp to this status utility file for centralizing status information.