### PR TITLE
feat(http): implement stateful ChunkedBodyParser (#88)

### DIFF
--- a/config/example.conf
+++ b/config/example.conf
@@ -1,6 +1,6 @@
 server {
     listen localhost:9191;
-    root website;
+    root www;
 
     max_body_size 50;
 

--- a/inc/http/RequestParser.hpp
+++ b/inc/http/RequestParser.hpp
@@ -68,6 +68,7 @@ private:
 
     void handleChunkedBody();
     void handleContentLengthBody();
+    bool writeToBodyFile(const std::string& data);
 
     /**
      * @brief Sets the parser to an error state and updates the Request's status.

--- a/src/http/internal/ChunkedBodyParser.cpp
+++ b/src/http/internal/ChunkedBodyParser.cpp
@@ -1,33 +1,248 @@
 #include "http/internal/ChunkedBodyParser.hpp"
+#include <algorithm>
+#include <climits>
 
 namespace http {
 
-ChunkedBodyParser::ChunkedBodyParser(utils::TempFile &file)
-    : state_(PARSING_CHUNK_SIZE), bodyFile_(file), maxBodySize_(0), bytesWritten_(0),
-      chunkBytesLeft_(0), errorStatus_(OK) {}
+namespace {
+
+const size_t NPOS = static_cast<size_t>(-1);
+
+int hexDigitValue(char c) {
+    if (c >= '0' && c <= '9')
+        return c - '0';
+    if (c >= 'a' && c <= 'f')
+        return 10 + (c - 'a');
+    if (c >= 'A' && c <= 'F')
+        return 10 + (c - 'A');
+    return -1;
+}
+
+size_t findCRLF(const char* input, size_t size) {
+    for (size_t i = 0; i + 1 < size; ++i) {
+        if (input[i] == '\r' && input[i + 1] == '\n')
+            return i;
+    }
+    return NPOS;
+}
+
+} // anonymous namespace
+
+ChunkedBodyParser::ParseResult ChunkedBodyParser::ParseResult::success(size_t n) {
+    ParseResult r;
+    r.ok = true;
+    r.consumed = n;
+    return r;
+}
+
+ChunkedBodyParser::ParseResult ChunkedBodyParser::ParseResult::needMore() {
+    ParseResult r;
+    r.ok = true;
+    r.consumed = 0;
+    return r;
+}
+
+ChunkedBodyParser::ParseResult ChunkedBodyParser::ParseResult::error() {
+    ParseResult r;
+    r.ok = false;
+    r.consumed = 0;
+    return r;
+}
+
+ChunkedBodyParser::ChunkedBodyParser()
+    : state_(READING_SIZE)
+    , bytesRemainingInChunk_(0)
+    , totalBytesWritten_(0)
+    , maxBodySize_(0)
+    , errorStatus_(OK)
+    , sawCR_(false) {
+}
 
 void ChunkedBodyParser::reset() {
-    state_ = PARSING_CHUNK_SIZE;
+    state_ = READING_SIZE;
+    sizeBuffer_.clear();
+    bytesRemainingInChunk_ = 0;
+    totalBytesWritten_ = 0;
     maxBodySize_ = 0;
-    bytesWritten_ = 0;
-    chunkBytesLeft_ = 0;
     errorStatus_ = OK;
+    sawCR_ = false;
 }
 
-ChunkedBodyParser::State ChunkedBodyParser::state() const { return state_; }
-HttpStatus ChunkedBodyParser::errorStatus() const { return errorStatus_; }
-void ChunkedBodyParser::setMaxBodySize(size_t size) { maxBodySize_ = size; }
-ChunkedBodyParser::State ChunkedBodyParser::setError(HttpStatus status) {
-    state_ = ERROR;
+HttpStatus ChunkedBodyParser::errorStatus() const {
+    return errorStatus_;
+}
+
+void ChunkedBodyParser::setMaxBodySize(size_t size) {
+    maxBodySize_ = size;
+}
+
+ChunkedBodyParser::ParseResult ChunkedBodyParser::setError(HttpStatus status) {
+    state_ = DONE;
     errorStatus_ = status;
-    return state_;
+    return ParseResult::error();
 }
 
-// TODO: finish this implementation (will modify state_ and bodyFile_ when implemented)
-ChunkedBodyParser::State ChunkedBodyParser::feed(std::string const &buffer) {
-    (void)buffer;
-    (void)bodyFile_;
-    return DONE;
+bool ChunkedBodyParser::parseHex(const std::string& hex, size_t& result) const {
+    if (hex.empty())
+        return false;
+
+    result = 0;
+    for (size_t i = 0; i < hex.size(); ++i) {
+        int digit = hexDigitValue(hex[i]);
+        if (digit < 0)
+            return false;
+        if (result > (static_cast<size_t>(-1) - digit) / 16)
+            return false;
+        result = result * 16 + digit;
+    }
+    return true;
+}
+
+ChunkedBodyParser::ParseResult ChunkedBodyParser::readSize(
+    const char* input, size_t size, std::string& output) {
+    std::string* outputPtr = &output;
+    (void)outputPtr;
+
+    size_t prevBufferLen = sizeBuffer_.size();
+    sizeBuffer_.append(input, size);
+
+    size_t crlfPos = findCRLF(sizeBuffer_.c_str(), sizeBuffer_.size());
+    if (crlfPos == NPOS)
+        return ParseResult::success(size);
+
+    std::string hex = sizeBuffer_.substr(0, crlfPos);
+    size_t lineEndInBuffer = crlfPos + 2;
+    size_t consumedFromInput = 0;
+    if (lineEndInBuffer > prevBufferLen)
+        consumedFromInput = lineEndInBuffer - prevBufferLen;
+
+    sizeBuffer_.clear();
+
+    size_t chunkSize = 0;
+    if (!parseHex(hex, chunkSize))
+        return setError(BAD_REQUEST);
+
+    if (chunkSize == 0) {
+        state_ = READING_FINAL_CRLF;
+        return ParseResult::success(consumedFromInput);
+    }
+
+    if (maxBodySize_ > 0 && totalBytesWritten_ + chunkSize > maxBodySize_)
+        return setError(PAYLOAD_TOO_LARGE);
+
+    bytesRemainingInChunk_ = chunkSize;
+    state_ = READING_DATA;
+    return ParseResult::success(consumedFromInput);
+}
+
+ChunkedBodyParser::ParseResult ChunkedBodyParser::readData(
+    const char* input, size_t size, std::string& output) {
+
+    size_t toRead = std::min(size, bytesRemainingInChunk_);
+
+    if (maxBodySize_ > 0 && totalBytesWritten_ + toRead > maxBodySize_)
+        return setError(PAYLOAD_TOO_LARGE);
+
+    output.append(input, toRead);
+    totalBytesWritten_ += toRead;
+    bytesRemainingInChunk_ -= toRead;
+
+    if (bytesRemainingInChunk_ == 0)
+        state_ = READING_TRAILER_CRLF;
+
+    return ParseResult::success(toRead);
+}
+
+ChunkedBodyParser::ParseResult ChunkedBodyParser::readTrailerCrlf(
+    const char* input, size_t size, std::string& output) {
+    std::string* outputPtr = &output;
+    (void)outputPtr;
+
+    if (sawCR_) {
+        if (input[0] != '\n')
+            return setError(BAD_REQUEST);
+        sawCR_ = false;
+        state_ = READING_SIZE;
+        return ParseResult::success(1);
+    }
+
+    if (size < 2) {
+        if (input[0] != '\r')
+            return setError(BAD_REQUEST);
+        sawCR_ = true;
+        return ParseResult::success(1);
+    }
+
+    if (input[0] != '\r' || input[1] != '\n')
+        return setError(BAD_REQUEST);
+
+    state_ = READING_SIZE;
+    return ParseResult::success(2);
+}
+
+ChunkedBodyParser::ParseResult ChunkedBodyParser::readFinalCrlf(
+    const char* input, size_t size, std::string& output) {
+    std::string* outputPtr = &output;
+    (void)outputPtr;
+
+    if (sawCR_) {
+        if (input[0] != '\n')
+            return setError(BAD_REQUEST);
+        sawCR_ = false;
+        state_ = DONE;
+        return ParseResult::success(1);
+    }
+
+    if (size < 2) {
+        if (input[0] != '\r')
+            return setError(BAD_REQUEST);
+        sawCR_ = true;
+        return ParseResult::success(1);
+    }
+
+    if (input[0] != '\r' || input[1] != '\n')
+        return setError(BAD_REQUEST);
+
+    state_ = DONE;
+    return ParseResult::success(2);
+}
+
+ChunkedBodyParser::Status ChunkedBodyParser::parse(
+    const char* input, size_t size,
+    std::string& output, size_t& bytesConsumed) {
+
+    static const StateHandler handlers[] = {
+        &ChunkedBodyParser::readSize,
+        &ChunkedBodyParser::readData,
+        &ChunkedBodyParser::readTrailerCrlf,
+        &ChunkedBodyParser::readFinalCrlf,
+        NULL
+    };
+
+    bytesConsumed = 0;
+    size_t pos = 0;
+
+    while (pos < size && state_ != DONE) {
+        StateHandler handler = handlers[state_];
+        if (handler == NULL)
+            break;
+
+        ParseResult result = (this->*handler)(input + pos, size - pos, output);
+
+        if (!result.ok)
+            return CHUNK_ERROR;
+
+        if (result.consumed == 0)
+            break;
+
+        pos += result.consumed;
+    }
+
+    bytesConsumed = pos;
+
+    if (state_ == DONE)
+        return CHUNK_DONE;
+    return CHUNK_CONTINUE;
 }
 
 } // namespace http

--- a/tests/http/ChunkedBodyParser.cpp
+++ b/tests/http/ChunkedBodyParser.cpp
@@ -1,0 +1,208 @@
+#include "http/internal/ChunkedBodyParser.hpp"
+#include "doctest.h"
+#include <string>
+
+TEST_CASE("ChunkedBodyParser basic parsing") {
+    http::ChunkedBodyParser parser;
+
+    SUBCASE("Single chunk") {
+        std::string input = "5\r\nHello\r\n0\r\n\r\n";
+        std::string output;
+        size_t consumed = 0;
+
+        http::ChunkedBodyParser::Status status =
+            parser.parse(input.c_str(), input.size(), output, consumed);
+
+        CHECK(status == http::ChunkedBodyParser::CHUNK_DONE);
+        CHECK(output == "Hello");
+        CHECK(consumed == input.size());
+    }
+
+    SUBCASE("Multiple chunks") {
+        std::string input = "5\r\nHello\r\n6\r\n World\r\n0\r\n\r\n";
+        std::string output;
+        size_t consumed = 0;
+
+        http::ChunkedBodyParser::Status status =
+            parser.parse(input.c_str(), input.size(), output, consumed);
+
+        CHECK(status == http::ChunkedBodyParser::CHUNK_DONE);
+        CHECK(output == "Hello World");
+        CHECK(consumed == input.size());
+    }
+
+    SUBCASE("Empty body (just final chunk)") {
+        std::string input = "0\r\n\r\n";
+        std::string output;
+        size_t consumed = 0;
+
+        http::ChunkedBodyParser::Status status =
+            parser.parse(input.c_str(), input.size(), output, consumed);
+
+        CHECK(status == http::ChunkedBodyParser::CHUNK_DONE);
+        CHECK(output.empty());
+        CHECK(consumed == input.size());
+    }
+
+    SUBCASE("Uppercase hex") {
+        std::string input = "A\r\n0123456789\r\n0\r\n\r\n";
+        std::string output;
+        size_t consumed = 0;
+
+        http::ChunkedBodyParser::Status status =
+            parser.parse(input.c_str(), input.size(), output, consumed);
+
+        CHECK(status == http::ChunkedBodyParser::CHUNK_DONE);
+        CHECK(output == "0123456789");
+    }
+
+    SUBCASE("Lowercase hex") {
+        std::string input = "a\r\n0123456789\r\n0\r\n\r\n";
+        std::string output;
+        size_t consumed = 0;
+
+        http::ChunkedBodyParser::Status status =
+            parser.parse(input.c_str(), input.size(), output, consumed);
+
+        CHECK(status == http::ChunkedBodyParser::CHUNK_DONE);
+        CHECK(output == "0123456789");
+    }
+}
+
+TEST_CASE("ChunkedBodyParser incremental parsing") {
+    http::ChunkedBodyParser parser;
+
+    SUBCASE("Partial chunk size") {
+        std::string output;
+        size_t consumed = 0;
+
+        http::ChunkedBodyParser::Status status =
+            parser.parse("5", 1, output, consumed);
+        CHECK(status == http::ChunkedBodyParser::CHUNK_CONTINUE);
+
+        status = parser.parse("\r\nHello\r\n0\r\n\r\n", 14, output, consumed);
+        CHECK(status == http::ChunkedBodyParser::CHUNK_DONE);
+        CHECK(output == "Hello");
+    }
+
+    SUBCASE("Partial chunk data") {
+        std::string output;
+        size_t consumed = 0;
+
+        http::ChunkedBodyParser::Status status =
+            parser.parse("5\r\nHel", 6, output, consumed);
+        CHECK(status == http::ChunkedBodyParser::CHUNK_CONTINUE);
+        CHECK(output == "Hel");
+
+        status = parser.parse("lo\r\n0\r\n\r\n", 9, output, consumed);
+        CHECK(status == http::ChunkedBodyParser::CHUNK_DONE);
+        CHECK(output == "Hello");
+    }
+
+    SUBCASE("Byte by byte") {
+        std::string input = "3\r\nabc\r\n0\r\n\r\n";
+        std::string output;
+        size_t consumed = 0;
+        size_t pos = 0;
+
+        while (pos < input.size()) {
+            http::ChunkedBodyParser::Status status =
+                parser.parse(input.c_str() + pos, 1, output, consumed);
+            pos += consumed;
+            if (pos < input.size()) {
+                CHECK(status == http::ChunkedBodyParser::CHUNK_CONTINUE);
+            } else {
+                CHECK(status == http::ChunkedBodyParser::CHUNK_DONE);
+            }
+        }
+        CHECK(output == "abc");
+    }
+}
+
+TEST_CASE("ChunkedBodyParser error handling") {
+    http::ChunkedBodyParser parser;
+
+    SUBCASE("Invalid hex character") {
+        std::string input = "XYZ\r\n";
+        std::string output;
+        size_t consumed = 0;
+
+        http::ChunkedBodyParser::Status status =
+            parser.parse(input.c_str(), input.size(), output, consumed);
+
+        CHECK(status == http::ChunkedBodyParser::CHUNK_ERROR);
+        CHECK(parser.errorStatus() == http::BAD_REQUEST);
+    }
+
+    SUBCASE("Missing CRLF after chunk data") {
+        std::string input = "5\r\nHelloX";
+        std::string output;
+        size_t consumed = 0;
+
+        http::ChunkedBodyParser::Status status =
+            parser.parse(input.c_str(), input.size(), output, consumed);
+
+        CHECK(status == http::ChunkedBodyParser::CHUNK_ERROR);
+        CHECK(parser.errorStatus() == http::BAD_REQUEST);
+    }
+}
+
+TEST_CASE("ChunkedBodyParser size limits") {
+    http::ChunkedBodyParser parser;
+    parser.setMaxBodySize(10);
+
+    SUBCASE("Within limit") {
+        std::string input = "5\r\nHello\r\n0\r\n\r\n";
+        std::string output;
+        size_t consumed = 0;
+
+        http::ChunkedBodyParser::Status status =
+            parser.parse(input.c_str(), input.size(), output, consumed);
+
+        CHECK(status == http::ChunkedBodyParser::CHUNK_DONE);
+        CHECK(output == "Hello");
+    }
+
+    SUBCASE("Exceeds limit in chunk size") {
+        std::string input = "F\r\n";
+        std::string output;
+        size_t consumed = 0;
+
+        http::ChunkedBodyParser::Status status =
+            parser.parse(input.c_str(), input.size(), output, consumed);
+
+        CHECK(status == http::ChunkedBodyParser::CHUNK_ERROR);
+        CHECK(parser.errorStatus() == http::PAYLOAD_TOO_LARGE);
+    }
+
+    SUBCASE("Exceeds limit across chunks") {
+        std::string input = "5\r\nHello\r\n6\r\n World\r\n0\r\n\r\n";
+        std::string output;
+        size_t consumed = 0;
+
+        http::ChunkedBodyParser::Status status =
+            parser.parse(input.c_str(), input.size(), output, consumed);
+
+        CHECK(status == http::ChunkedBodyParser::CHUNK_ERROR);
+        CHECK(parser.errorStatus() == http::PAYLOAD_TOO_LARGE);
+    }
+}
+
+TEST_CASE("ChunkedBodyParser reset") {
+    http::ChunkedBodyParser parser;
+
+    std::string input = "5\r\nHello\r\n0\r\n\r\n";
+    std::string output;
+    size_t consumed = 0;
+
+    http::ChunkedBodyParser::Status status =
+        parser.parse(input.c_str(), input.size(), output, consumed);
+    CHECK(status == http::ChunkedBodyParser::CHUNK_DONE);
+
+    parser.reset();
+    output.clear();
+
+    status = parser.parse(input.c_str(), input.size(), output, consumed);
+    CHECK(status == http::ChunkedBodyParser::CHUNK_DONE);
+    CHECK(output == "Hello");
+}


### PR DESCRIPTION
Implement HTTP/1.1 Transfer-Encoding: chunked support with clean patterns:
- Dispatch table pattern (no switch-case)
- Guard clauses with early returns (no nested if-else)
- Internal ParseResult type for clean error handling
- Incremental byte-by-byte parsing support

Changes:
- Rewrite ChunkedBodyParser with new parse() interface
- Integrate into RequestParser::handleChunkedBody()
- Add comprehensive unit tests
- Fix config/example.conf root path (website -> www)