### PR TITLE
feat: implement Connection header support (keep-alive/close)

### DIFF
--- a/inc/common/string.hpp
+++ b/inc/common/string.hpp
@@ -20,5 +20,6 @@ template <typename T> T fromString(std::string const &str) {
 std::string trim(const std::string &s);
 
 bool isAllDigit(std::string const &s);
+void toLower(std::string &s);
 
 } // namespace utils

--- a/inc/network/ClientHandler.hpp
+++ b/inc/network/ClientHandler.hpp
@@ -102,6 +102,7 @@ private:
     http::RequestParser reqParser_;
 
     // Response State
+    bool isKeepAlive_;
     SendBuffer rspBuffer_;
     CgiState cgiState_;
 

--- a/src/common/string.cpp
+++ b/src/common/string.cpp
@@ -1,5 +1,7 @@
 #include "common/string.hpp"
 
+#include <algorithm>
+
 namespace utils {
 
 std::string trim(const std::string &s) {
@@ -18,5 +20,7 @@ bool isAllDigit(std::string const &s) {
     }
     return true;
 }
+
+void toLower(std::string &s) { std::transform(s.begin(), s.end(), s.begin(), ::tolower); }
 
 } // namespace utils


### PR DESCRIPTION
- Update ClientHandler to determine connection state from request
- Add Connection header to responses
- Handle HTTP/1.1 (default keep-alive) and HTTP/1.0 (default close)
- Add utils::toLower to string utilities
---
Closes #59 