### PR TITLE
feat(http): support lenient LF-only line endings for netcat compatibility

### DIFF
--- a/inc/http/Headers.hpp
+++ b/inc/http/Headers.hpp
@@ -109,10 +109,19 @@ public:
      * @param strict If true, parsing is strict; otherwise, more lenient.
      * @return True if parsing succeeded, false otherwise.
      */
-    static bool parse(std::string &, Headers &, bool strict = true);
+    static bool parse(std::string &, Headers &, bool strict = false);
 
     /** @copydoc parse */
-    static bool parse(std::istringstream &, Headers &, bool strict = true);
+    static bool parse(std::istringstream &, Headers &, bool strict = false);
+
+    /**
+     * @brief Finds the end of the HTTP header section in a buffer.
+     * Compatible with \r\n\r\n, \n\n, \r\n\n, and \n\r\n.
+     * @param buffer The input buffer to search.
+     * @param[out] offset The length of the delimiter found (2, 3, or 4).
+     * @return The starting position of the delimiter, or std::string::npos if not found.
+     */
+    static size_t findHeaderEnd(const std::string &buffer, size_t &offset);
 
 private:
     /**

--- a/src/http/Headers.cpp
+++ b/src/http/Headers.cpp
@@ -115,4 +115,20 @@ Headers::const_iterator Headers::find(std::string const &key) const {
     return map_.find(normalizeKey(key));
 }
 
+size_t Headers::findHeaderEnd(const std::string &buffer, size_t &offset) {
+    for (size_t i = 0; i < buffer.size(); ++i) {
+        if (buffer[i] == '\n') {
+            if (i + 1 < buffer.size() && buffer[i + 1] == '\n') {
+                offset = (i > 0 && buffer[i - 1] == '\r') ? 3 : 2;
+                return (i > 0 && buffer[i - 1] == '\r') ? i - 1 : i;
+            }
+            if (i + 2 < buffer.size() && buffer[i + 1] == '\r' && buffer[i + 2] == '\n') {
+                offset = (i > 0 && buffer[i - 1] == '\r') ? 4 : 3;
+                return (i > 0 && buffer[i - 1] == '\r') ? i - 1 : i;
+            }
+        }
+    }
+    return std::string::npos;
+}
+
 } // namespace http

--- a/src/network/ClientHandler.cpp
+++ b/src/network/ClientHandler.cpp
@@ -360,6 +360,7 @@ void ClientHandler::finalizeConnection() {
         LOG_SDEBUG("Keep-Alive. Resetting.");
         resetForNewRequest();
         EventDispatcher::getInstance().enableRead(this);
+        EventDispatcher::getInstance().disableWrite(this);
     } else {
         closeConnection();
     }

--- a/src/network/handlers/CGIHandler.cpp
+++ b/src/network/handlers/CGIHandler.cpp
@@ -62,18 +62,9 @@ void CGIHandler::handleRead() {
         return client_.handleError(http::BAD_GATEWAY);
     }
     headerBuffer_.append(buffer, bytes_read);
-    size_t headerEnd = headerBuffer_.find("\r\n\r\n");
-    size_t offset = 4;
 
-    if (headerEnd == std::string::npos) {
-        headerEnd = headerBuffer_.find("\n\n");
-        offset = 2;
-    }
-
-    if (headerEnd == std::string::npos) {
-        headerEnd = headerBuffer_.find("\n\r\n");
-        offset = 3;
-    }
+    size_t offset = 0;
+    size_t headerEnd = http::Headers::findHeaderEnd(headerBuffer_, offset);
     if (headerEnd == std::string::npos) {
         return;
     }


### PR DESCRIPTION
Enables the server to parse requests using only LF (\n) as line terminators, allowing full compatibility with netcat and manual telnet sessions.
