### PR TITLE
feat(http): refactor Request body management and add moveBody

### DIFF
--- a/config/example.conf
+++ b/config/example.conf
@@ -2,23 +2,25 @@ server {
     listen localhost:9191;
     root www;
 
-    max_body_size 50;
+    max_body_size 100;
 
     location / {
         index index.html;
     }
 
     location /img/ {
-        root img;
         upload_path upload;
+        autoindex on;
     }
 
-    location /cgi/ {
+    location /uploads/ {
+        upload_path uploads;
+        autoindex on;
+        allowed_methods GET POST DELETE;
+    }
+
+    location /cgi-bin/ {
         cgi_pass;
-    }
-
-    location /docs/ {
-        alias doxy/html;
-        index index.html;
+        allowed_methods GET POST;
     }
 }

--- a/inc/http/FileUploadValidator.hpp
+++ b/inc/http/FileUploadValidator.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "http/HttpStatus.hpp"
 
 #include "http/MimeTypes.hpp"
@@ -26,10 +28,10 @@ namespace http::upload {
  *                              and message.
  */
 struct UploadValidationResult {
-    bool result;              ///< True if validation succeeded.
-    std::string filename;     ///< Parsed or validated filename (empty if failed).
-    HttpStatus status;        ///< HTTP status code associated with the result.
-    std::string message;      ///< Detailed error message if validation failed.
+    bool result;          ///< True if validation succeeded.
+    std::string filename; ///< Parsed or validated filename (empty if failed).
+    HttpStatus status;    ///< HTTP status code associated with the result.
+    std::string message;  ///< Detailed error message if validation failed.
 
     /// @brief Creates a successful validation result with a filename.
     static UploadValidationResult ok(const std::string &file);
@@ -40,7 +42,6 @@ struct UploadValidationResult {
     /// @brief Creates a failed validation result.
     static UploadValidationResult fail(HttpStatus s, const std::string &msg);
 };
-
 
 std::string extractHeaderParam(const std::string &str, const std::string &toFind);
 

--- a/inc/http/RequestParser.hpp
+++ b/inc/http/RequestParser.hpp
@@ -68,7 +68,7 @@ private:
 
     void handleChunkedBody();
     void handleContentLengthBody();
-    bool writeToBodyFile(const std::string& data);
+    bool writeToBodyFile(const std::string &data);
 
     /**
      * @brief Sets the parser to an error state and updates the Request's status.
@@ -91,7 +91,6 @@ private:
 
     Request &request_;
 
-    utils::TempFile bodyFile_;
     ChunkedBodyParser chunkParser_;
 };
 

--- a/src/http/Request.cpp
+++ b/src/http/Request.cpp
@@ -60,7 +60,9 @@ char const *RequestStartLine::methodToString(Method m) {
     }
 }
 
-Request::Request() : body_(-1), location_(NULL), server_(NULL), status_(OK), remoteAddr_("") {}
+Request::Request() : body_(NULL), location_(NULL), server_(NULL), status_(OK), remoteAddr_("") {}
+
+Request::~Request() { delete body_; }
 
 bool Request::wantsJson() const { return headers_.get("Accept") == "application/json"; }
 
@@ -73,7 +75,8 @@ void Request::clear() {
     location_ = NULL;
     server_ = NULL;
     status_ = OK;
-    body_ = -1;
+    delete body_;
+    body_ = NULL;
     remoteAddr_.clear();
 }
 
@@ -103,11 +106,18 @@ Request &Request::uri(std::string const &uri) {requestLine_.uri = uri;return *th
 Request &Request::version(std::string const &version) {requestLine_.version= version;return *this;}
 Request &Request::status(HttpStatus statusCode) { status_ = statusCode; return *this; }
 HttpStatus Request::status() const { return status_; }
-int Request::body() const { return body_; }
-const std::string &Request::bodyPath() const { return bodyPath_; }
-Request &Request::bodyPath(const std::string &path) {bodyPath_ = path; return *this;}
-Request &Request::body(int fd) { body_ = fd; return *this; }
-Request &Request::body(int fd, const std::string &path) {body_ = fd; bodyPath_ = path; return *this; };
+utils::TempFile const *Request::body() const { return body_; }
+utils::TempFile *Request::body() { return body_; }
+const std::string &Request::bodyPath() const {
+    static const std::string empty;
+    return body_ ? body_->path() : empty;
+}
+
+utils::TempFile::MoveStatus Request::moveBody(const std::string &destPath) const {
+    if (!body_)
+        return utils::TempFile::MOVE_INVALID_STATE;
+    return body_->moveTo(destPath);
+}
 std::string const &Request::remoteAddr() const { return remoteAddr_; }
 Request &Request::remoteAddr(std::string const &addr) { remoteAddr_ = addr; return *this; }
 // clang-format on

--- a/src/http/RequestParser.cpp
+++ b/src/http/RequestParser.cpp
@@ -25,7 +25,6 @@ void RequestParser::reset() {
     maxContentSize_ = 0;
     isContentChunked_ = false;
     buffer_.clear();
-    bodyFile_.close();
     request_.clear();
 }
 
@@ -106,8 +105,11 @@ RequestParser::State RequestParser::parseHeaders() {
 }
 
 RequestParser::State RequestParser::parseBody() {
-    if (!bodyFile_.isOpen() && !bodyFile_.open()) {
-        LOG_ERROR("RequestParser::handleBody(): Failed to open TempFile. State=ERROR");
+    if (!request_.body_) {
+        request_.body_ = new utils::TempFile();
+    }
+    if (!request_.body_->isOpen() && !request_.body_->open()) {
+        LOG_SERROR("Failed to open TempFile. State=ERROR");
         return setError(INTERNAL_SERVER_ERROR);
     }
     if (isContentChunked_) {
@@ -127,10 +129,10 @@ void RequestParser::handleContentLengthBody() {
     size_t bytesToWrite = std::min(buffer_.length(), bytesLeftToWrite);
     if (!bytesToWrite)
         return;
-    ssize_t written = write(bodyFile_, buffer_.c_str(), bytesToWrite);
+    ssize_t written = write(request_.body_->fd(), buffer_.c_str(), bytesToWrite);
 
     if (written < 0) {
-        LOG_ERROR("RequestParser::handleContentLengthBody(): Write error to TempFile.");
+        LOG_SERROR("Write error to TempFile.");
         return (void)setError(INTERNAL_SERVER_ERROR);
     }
 
@@ -143,7 +145,9 @@ void RequestParser::handleContentLengthBody() {
 }
 
 bool RequestParser::writeToBodyFile(const std::string &data) {
-    ssize_t written = write(bodyFile_, data.c_str(), data.size());
+    if (!request_.body_)
+        return false;
+    ssize_t written = write(request_.body_->fd(), data.c_str(), data.size());
     if (written < 0) {
         LOG_ERROR("RequestParser::writeToBodyFile(): Write error to TempFile.");
         setError(INTERNAL_SERVER_ERROR);
@@ -182,10 +186,8 @@ void RequestParser::handleChunkedBody() {
 
 void RequestParser::setRequestReady() {
     state_ = REQUEST_READY;
-    if (bodyFile_.isOpen()) {
-        if (lseek(bodyFile_, 0, SEEK_SET) != (off_t)-1) {
-            request_.body(bodyFile_, bodyFile_.path());
-        } else {
+    if (request_.body_ && request_.body_->isOpen()) {
+        if (lseek(request_.body_->fd(), 0, SEEK_SET) == (off_t)-1) {
             LOG_ERROR("RequestParser::setRequestReady(): lseek failed on TempFile. State=ERROR");
             setError(INTERNAL_SERVER_ERROR);
         }

--- a/src/http/handlers/CGIHandler.cpp
+++ b/src/http/handlers/CGIHandler.cpp
@@ -111,8 +111,8 @@ void CGIHandler::runChildProcess() {
     }
     close(pipeFd_[1]);
 
-    if (req_.body() >= 0) {
-        if (dup2(req_.body(), STDIN_FILENO) == -1) {
+    if (req_.body()) {
+        if (dup2(req_.body()->fd(), STDIN_FILENO) == -1) {
             print_errno_to_fd(errorFd_[1], errno);
             _exit(1);
         }

--- a/src/http/handlers/FileUploadHandler.cpp
+++ b/src/http/handlers/FileUploadHandler.cpp
@@ -45,7 +45,7 @@ void FileUploadHandler::handle(Request const &req, Response &res, MimeTypes cons
         return (void)res.status(vup.status, vup.message);
     }
 
-    if (req.body() < 0) {
+    if (!req.body()) {
         return (void)res.status(BAD_REQUEST, "No body provided for upload");
     }
 
@@ -72,13 +72,13 @@ void FileUploadHandler::handle(Request const &req, Response &res, MimeTypes cons
     }
     path += pf.filename;
 
-    LOG_DEBUG("UPLOAD PATH:   " + path);
+    LOG_SDEBUG("UPLOAD PATH: " + path);
     if (access(path.c_str(), F_OK) == 0) {
         return (void)res.status(CONFLICT, "File already exists");
     }
-    int writeRes = utils::TempFile::moveOrCopyFile(req.bodyPath(), path);
-    if (writeRes != 0) {
-        LOG_DEBUG("utils::moveOrCopyFile(req.bodyPath(), path.c_str()) reported an error");
+    utils::TempFile::MoveStatus moveRes = req.moveBody(path);
+    if (moveRes != utils::TempFile::MOVE_SUCCESS) {
+        LOG_SERROR("req.moveBody(path) reported error status: " << moveRes);
         return (void)res.status(INTERNAL_SERVER_ERROR, "Failed to write uploaded file to disk");
     }
 


### PR DESCRIPTION
## Overview
This PR refines the file upload system by refactoring how the Request class manages temporary bodies and improving filename resolution logic.

## Key Changes
- **Request Class Refactor**:
    - **Managed Body**: Transitioned from raw int file descriptors to `utils::TempFile*` pointers. This allows the Request object to own the lifecycle of temporary files.
    - **Added moveBody()**: Introduced a high-level API for relocating request bodies to permanent storage. It returns a descriptive `MoveStatus` enum (e.g., `MOVE_SUCCESS`, `MOVE_IO_ERR`) instead of magic integers.
    - **Resource Safety**: Implemented the Request destructor and updated clear() to ensure temporary files are unlinked/closed properly upon request completion.
- **Filename Resolution**:
    - **URI Fallback**: The validator now supports extracting the filename from the URI path (e.g., `POST /uploads/file.txt`), removing the strict requirement for `X-Filename` or `Content-Disposition` headers.
    - **Relaxed Handlers**: Decoupled strict MIME-type matching to allow raw binary uploads from tools like `curl`.
- **Filesystem Robustness**: 
    - Updated `TempFile::moveTo` with an atomic `rename()` implementation and a high-performance manual copy fallback to handle cross-device move failures.
    - Added detailed logging with `strerror(errno)` for easier debugging of disk/permission issues.